### PR TITLE
feat: 에디터 기본 레이아웃과 기본 Scene 구성 화면 설정

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,6 +37,7 @@ function createWindow() {
     },
     width: DEFAULT_WINDOW_WIDTH,
     height: DEFAULT_WINDOW_HEIGHT,
+    autoHideMenuBar: true,
   });
 
   // Test active push message to Renderer-process.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Virtual Studio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "jeasings": "^0.0.16",
+    "lucide-react": "^0.536.0",
     "pnpm": "^10.14.0",
     "pretendard": "^1.3.9",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,19 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
+    "@types/three": "^0.178.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jeasings": "^0.0.16",
     "pnpm": "^10.14.0",
     "pretendard": "^1.3.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.7.1",
+    "react-split": "^2.0.14",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "three": "^0.179.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       jeasings:
         specifier: ^0.0.16
         version: 0.0.16
+      lucide-react:
+        specifier: ^0.536.0
+        version: 0.536.0(react@18.3.1)
       pnpm:
         specifier: ^10.14.0
         version: 10.14.0
@@ -1676,6 +1679,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@0.536.0:
+    resolution: {integrity: sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -4090,6 +4098,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@0.536.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   magic-string@0.30.17:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@5.4.19(@types/node@24.1.0)(lightningcss@1.30.1))
+      '@types/three':
+        specifier: ^0.178.1
+        version: 0.178.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jeasings:
+        specifier: ^0.0.16
+        version: 0.0.16
       pnpm:
         specifier: ^10.14.0
         version: 10.14.0
@@ -32,12 +38,18 @@ importers:
       react-router-dom:
         specifier: ^7.7.1
         version: 7.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-split:
+        specifier: ^2.0.14
+        version: 2.0.14(react@18.3.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
+      three:
+        specifier: ^0.179.1
+        version: 0.179.1
     devDependencies:
       '@types/react':
         specifier: ^18.2.64
@@ -183,6 +195,9 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -625,6 +640,9 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -681,8 +699,17 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.178.1':
+    resolution: {integrity: sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==}
+
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/webxr@0.5.22':
+    resolution: {integrity: sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -753,6 +780,9 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@webgpu/types@0.1.64':
+    resolution: {integrity: sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==}
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -1240,6 +1270,9 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1481,6 +1514,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jeasings@0.0.16:
+    resolution: {integrity: sha512-BuAbUTdGBBv1L+MCJ0+bbhM2x4ddnnVwPlx0/ZdlKQz9xu8mJI1nWyKPQJB8QBcaeF3s1Lvn2ZaG1uExgpvu/w==}
+
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
@@ -1656,6 +1692,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -1749,6 +1788,10 @@ packages:
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -1907,6 +1950,9 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -1925,6 +1971,9 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1946,6 +1995,11 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-split@2.0.14:
+    resolution: {integrity: sha512-bKWydgMgaKTg/2JGQnaJPg51T6dmumTWZppFgEbbY0Fbme0F5TuatAScCLaqommbGQQf/ZT1zaejuPDriscISA==}
+    peerDependencies:
+      react: '*'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2080,6 +2134,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  split.js@1.6.5:
+    resolution: {integrity: sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -2148,6 +2205,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  three@0.179.1:
+    resolution: {integrity: sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -2443,6 +2503,8 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -2795,6 +2857,8 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.0
@@ -2870,8 +2934,22 @@ snapshots:
     dependencies:
       '@types/node': 20.19.9
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.178.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.22
+      '@webgpu/types': 0.1.64
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
+
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/webxr@0.5.22': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -2972,6 +3050,8 @@ snapshots:
       vite: 5.4.19(@types/node@24.1.0)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@webgpu/types@0.1.64': {}
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -3602,6 +3682,8 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
+  fflate@0.8.2: {}
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -3880,6 +3962,10 @@ snapshots:
       filelist: 1.0.4
       picocolors: 1.1.1
 
+  jeasings@0.0.16:
+    dependencies:
+      typescript: 5.9.2
+
   jiti@2.5.1: {}
 
   js-tokens@4.0.0: {}
@@ -4018,6 +4104,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  meshoptimizer@0.18.1: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -4084,6 +4172,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
+
+  object-assign@4.1.1: {}
 
   object-keys@1.1.1:
     optional: true
@@ -4169,6 +4259,12 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -4186,6 +4282,8 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@16.13.1: {}
+
   react-refresh@0.17.0: {}
 
   react-router-dom@7.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -4201,6 +4299,12 @@ snapshots:
       set-cookie-parser: 2.7.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
+
+  react-split@2.0.14(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.3.1
+      split.js: 1.6.5
 
   react@18.3.1:
     dependencies:
@@ -4356,6 +4460,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  split.js@1.6.5: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -4439,6 +4545,8 @@ snapshots:
       fs-extra: 10.1.0
 
   text-table@0.2.0: {}
+
+  three@0.179.1: {}
 
   tmp-promise@3.0.3:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,12 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import SceneEditor from "./pages/scene-editor";
 
 function App() {
   return (
     <div className="bg-black-500 text-text-primary relative flex h-screen max-h-screen w-screen max-w-full flex-col">
       <BrowserRouter>
         <Routes>
-          <Route
-            path="/"
-            element={
-              <div className="flex h-full w-full items-center justify-center text-2xl font-semibold">
-                Hello World!
-              </div>
-            }
-          />
+          <Route path="/" element={<SceneEditor />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/assets/controls/pointerlock.svg
+++ b/src/assets/controls/pointerlock.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <mask id="eye-mask">
+            <!-- Full Eye Shape (White means visible, Black means hidden) -->
+            <rect width="100" height="100" fill="white"/>
+            <!-- Transparent Pupil (Cutout Effect) -->
+             <circle cx="50" cy="50" r="15" fill="black" stroke="#353535" stroke-width="2"/>
+        </mask>
+    </defs>
+
+    <!-- Eye Shape with Mask Applied -->
+    
+    <circle cx="50" cy="50" r="10" fill="#f0f0f088" stroke="#353535" stroke-width="2"/>
+    <path d="M10 50 Q50 10, 90 50 Q50 90, 10 50 Z" fill="#f0f0f088" stroke="#353535" stroke-width="2" mask="url(#eye-mask)"/>        
+    
+</svg>

--- a/src/assets/material/material.svg
+++ b/src/assets/material/material.svg
@@ -1,0 +1,18 @@
+<svg width="50" height="50" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background Circle -->
+  <circle cx="25" cy="25" r="20" fill="url(#gradient)" stroke="white" stroke-width="3"/>
+  
+  <!-- Light Reflection -->
+  <circle cx="17" cy="17" r="7" fill="white" opacity="0.8"/>
+
+  <!-- Shadow -->
+  <!-- <ellipse cx="25" cy="40" rx="15" ry="5" fill="black" opacity="0.2"/> -->
+
+  <!-- Radial Gradient for Sphere -->
+  <defs>
+    <radialGradient id="gradient" cx="30%" cy="30%" r="70%">
+      <!-- <stop offset="0%" stop-color="#00000000"/> -->
+      <!-- <stop offset="0%" stop-color="#00000000"/> -->
+    </radialGradient>
+  </defs>
+</svg>

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,0 +1,16 @@
+import { icons } from "lucide-react";
+import { cn } from "@/utils/style";
+
+type TransformIconProps = {
+  icon: string;
+  size?: number;
+  className?: string;
+};
+
+export default function Icon({ icon, size, className }: TransformIconProps) {
+  const IconComponent = icons[icon as keyof typeof icons] ?? icons["Box"];
+
+  return (
+    <IconComponent className={cn(className)} fill={"transparent"} size={size} />
+  );
+}

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { cn } from "../utils/style";
+
+interface PanelProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function Panel({ children, className }: PanelProps) {
+  return (
+    <div className={cn(`relative flex h-full w-full flex-col items-center justify-center`)}>
+      <div className={cn(`h-full w-full bg-black px-[0.02rem] pt-[0.1rem]`, className)}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default Panel;

--- a/src/components/Split.tsx
+++ b/src/components/Split.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import SplitComponent from "react-split";
+import { cn } from "../utils/style";
+
+type SplitProps = {
+  size?: [number, number];
+  direction?: "horizontal" | "vertical";
+  children?: React.ReactNode;
+};
+
+export default function Split({
+  direction = "vertical",
+  size = [50, 50],
+  children,
+}: SplitProps) {
+  return (
+    <SplitComponent
+      gutterSize={1}
+      className={cn(
+        "flex w-full h-full relative",
+        direction === "vertical"
+          ? "flex-col gap-[0.075rem]"
+          : "flex-row gap-[0.075rem]"
+      )}
+      direction={direction}
+      minSize={31}
+      sizes={size}
+    >
+      {children}
+    </SplitComponent>
+  );
+}

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -1,0 +1,80 @@
+import React, { ComponentProps } from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "../../utils/style";
+
+type ToolMenuProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+function ToolbarContainer({ className, children }: ToolMenuProps) {
+  return (
+    <div
+      className={cn(
+        "bg-black-500 text-text-primary relative flex h-[1.8rem] w-full items-center rounded-t-md border-b-2 border-black px-1",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ToolbarGroup({ className, children }: ToolMenuProps) {
+  return <div className={cn("flex items-center gap-[0.1rem]", className)}>{children}</div>;
+}
+
+const toolMenuVariants = cva(
+  "bg-black-200 hover:bg-blue-300/80 cursor-pointer items-center justify-center flex text-gray-50 p-1 border-1 border-black-500 ",
+  {
+    variants: {
+      shape: {
+        rect: "rounded-sm",
+        round: "rounded-full",
+      },
+      size: {
+        sm: "w-5 h-5",
+        md: "w-6 h-6",
+        lg: "w-7 h-7",
+      },
+    },
+    defaultVariants: {
+      shape: "rect",
+      size: "md",
+    },
+  },
+);
+
+type ToolbarItemProps = ComponentProps<"div"> & {
+  shape: "rect" | "round";
+  size: "sm" | "md" | "lg";
+  className?: string;
+  children: React.ReactNode;
+  selected?: boolean;
+};
+
+function ToolbarItem({ shape, size, className, children, selected, ...props }: ToolbarItemProps) {
+  return (
+    <div
+      className={cn(
+        toolMenuVariants({
+          shape: shape,
+          size: size,
+        }),
+        selected && "border-1 border-blue-300 bg-blue-500 text-white",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+const Toolbar = {
+  Container: ToolbarContainer,
+  Group: ToolbarGroup,
+  Item: ToolbarItem,
+};
+
+export default Toolbar;

--- a/src/constants/camera.ts
+++ b/src/constants/camera.ts
@@ -1,0 +1,23 @@
+export const DEFAULT_CAMERA_SPEC = {
+  fov: 50,
+  near: 0.1,
+  far: 1000,
+};
+
+// export const DEFAULT_CAMERA_POSITION = {
+//   x: 5,
+//   y: 2.6,
+//   z: 5.7,
+// };
+
+export const DEFAULT_CAMERA_POSITION = {
+  x: 3,
+  y: 2.3,
+  z: 4.7,
+};
+
+export const DEFAULT_CAMERA_TARGET = {
+  x: 0,
+  y: 0,
+  z: 0,
+};

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -1,0 +1,15 @@
+// export const RGB_COLOR = {
+//   r: 0xd12f2a,
+//   g: 0x65ca32,
+//   b: 0x3462cd,
+// };
+
+export const RGB_COLOR = {
+  r: 0xff2244,
+  g: 0x88ff44,
+  b: 0x4488ff,
+};
+
+export const GRID_COLOR = 0x777777;
+
+export const SCENE_BACKGROUND_COLOR = "#424242";

--- a/src/constants/controls.ts
+++ b/src/constants/controls.ts
@@ -1,0 +1,15 @@
+export const CONTROLS_SPEED = 1000;
+
+export const PAN_SPEED = 0.01;
+
+export const ZOOM_SPEED = 1000;
+
+export const MOUSE_LEFT = 0;
+
+export const MOUSE_WHEEL = 1;
+
+export const MOUSE_RIGHT = 2;
+
+export const MICRO_SECOND = 1000;
+
+export const MOUSE_MOVE_THRESHOLD = 7;

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -1,0 +1,258 @@
+import { Context } from "../core/context";
+import { createMesh } from "../core/mesh";
+
+export interface MenuItem {
+  label: string;
+  icon: string;
+  subMenu?: MenuItem[];
+  callback?: () => void;
+  shortcut?: string;
+}
+export const SCENE_VIEW_HEADER_MENU_ITEMS: MenuItem[] = [
+  {
+    label: "File",
+    icon: "File",
+    subMenu: [
+      {
+        label: "New",
+        icon: "File",
+        callback: () => {
+          // createMesh("box");
+        },
+      },
+    ],
+  },
+  {
+    label: "Edit",
+    icon: "Edit",
+    subMenu: [],
+  },
+  {
+    label: "Render",
+    icon: "Render",
+    subMenu: [],
+  },
+  {
+    label: "View",
+    icon: "View",
+    subMenu: [],
+  },
+  {
+    label: "Window",
+    icon: "Window",
+    subMenu: [],
+  },
+  {
+    label: "Help",
+    icon: "Help",
+    subMenu: [],
+  },
+];
+
+const update = true;
+
+export const SCENE_VIEW_MENU_ITEMS: MenuItem[] = [
+  {
+    label: "Mesh",
+    icon: "Box",
+    subMenu: [
+      {
+        label: "Group",
+        icon: "Group",
+        callback: () => {
+          const mesh = createMesh("Group");
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "G",
+      },
+      {
+        label: "Plane",
+        icon: "Square",
+        callback: () => {
+          const mesh = createMesh("Plane");
+
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "P",
+      },
+      {
+        label: "Box",
+        icon: "Box",
+        callback: () => {
+          const mesh = createMesh("Box");
+
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "B",
+      },
+      {
+        label: "Sphere",
+        icon: "Sphere",
+        callback: () => {
+          const mesh = createMesh("Sphere");
+
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "S",
+      },
+      {
+        label: "Cylinder",
+        icon: "Cylinder",
+        callback: () => {
+          const mesh = createMesh("Cylinder");
+
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "C",
+      },
+      {
+        label: "Cone",
+        icon: "Cone",
+        callback: () => {
+          const mesh = createMesh("Cone");
+
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "O",
+      },
+      {
+        label: "Torus",
+        icon: "Torus",
+        callback: () => {
+          const mesh = createMesh("Torus");
+
+          const scene = Context.getInstance().scene;
+          scene?.addObject(mesh, update);
+          scene!.selectedObject = [mesh];
+        },
+        shortcut: "T",
+      },
+    ],
+  },
+  {
+    label: "Camera",
+    icon: "Video",
+    callback: () => {
+      console.log("Camera");
+    },
+    subMenu: [
+      {
+        label: "Perspective",
+        icon: "Video",
+        callback: () => {
+          console.log("Perspective");
+        },
+      },
+      {
+        label: "Orthographic",
+        icon: "Video",
+        callback: () => {
+          console.log("Orthographic");
+        },
+      },
+    ],
+  },
+  {
+    label: "Light",
+    icon: "Flashlight",
+    callback: () => {
+      console.log("Light");
+    },
+    subMenu: [
+      {
+        label: "Directional",
+        icon: "Flashlight",
+        callback: () => {
+          console.log("Directional");
+        },
+      },
+      {
+        label: "Point",
+        icon: "Flashlight",
+        callback: () => {
+          console.log("Point");
+        },
+      },
+    ],
+  },
+  {
+    label: "seperate",
+    icon: "seperate",
+  },
+  {
+    label: "Copy",
+    icon: "Copy",
+    callback: () => {
+      console.log("Copy");
+    },
+    shortcut: "⌘+C",
+  },
+  {
+    label: "Paste",
+    icon: "Clipboard",
+    callback: () => {
+      console.log("Paste");
+    },
+    shortcut: "⌘+V",
+  },
+];
+
+export const PROGRAM_MENU_ITEMS: MenuItem[] = [
+  {
+    label: "Layout",
+    icon: "Layout",
+    subMenu: [],
+  },
+  {
+    label: "Modeling",
+    icon: "Modeling",
+    subMenu: [],
+  },
+  {
+    label: "Sculpting",
+    icon: "Sculpting",
+    subMenu: [],
+  },
+  {
+    label: "UV Editing",
+    icon: "UV Editing",
+    subMenu: [],
+  },
+  {
+    label: "Texture Painting",
+    icon: "Texture Painting",
+    subMenu: [],
+  },
+  {
+    label: "Shading",
+    icon: "Shading",
+    subMenu: [],
+  },
+  {
+    label: "Animation",
+    icon: "Animation",
+    subMenu: [],
+  },
+  {
+    label: "Rendering",
+    icon: "Rendering",
+    subMenu: [],
+  },
+  {
+    label: "Simulation",
+    icon: "Simulation",
+    subMenu: [],
+  },
+];

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,0 +1,283 @@
+/*
+//
+// Scene-Editor에서 사용되는
+// Scene(Multi-Scene), Camera를 관리합니다.
+// 카메라는 다른 Scene이 겹쳐질 경우
+// 같은 카메라에서 어떻게 보이는지 확인을 위해 각 카메라 공유
+//
+*/
+
+import * as THREE from "three";
+import { Scene } from "./scene";
+import { PerspectiveControls } from "./perspective-controls";
+import { TransformControls } from "./transform-controls";
+import { OrthographicControls } from "./orthographic-controls";
+import { DEFAULT_CAMERA_SPEC } from "../constants/camera";
+import { ViewHelper } from "./view-helper";
+import JEASINGS from "jeasings";
+
+export class Context {
+  private static instance: Context;
+  private _renderer: THREE.WebGLRenderer = new THREE.WebGLRenderer({
+    antialias: true,
+    alpha: true,
+  });
+  private _id: number = 0;
+  private _scenes: Scene[] = [];
+  private _scene: Scene | null = null;
+  private _cameras: THREE.Camera[] = [];
+  private _camera: THREE.Camera | null = null;
+  private _controls: PerspectiveControls | OrthographicControls | null = null;
+  private _persepectiveControls: PerspectiveControls | null = null;
+  private _orthographicControls: OrthographicControls | null = null;
+  private _dom: HTMLDivElement | null = null;
+  private _transformControls: TransformControls | null = null;
+  private _listeners: (() => void)[] = [];
+  private _viewHelper: ViewHelper | null = null;
+
+  constructor() {
+    console.log("%cInitialize Scene Editor Context", "color: #00ffff;");
+    this._renderer.setClearColor(0x000000, 0);
+  }
+
+  public didMount(dom: HTMLDivElement) {
+    console.log("%cMounted SceneView", "color: #00ffff;");
+
+    this._dom = dom;
+    const scene = new Scene(`Scene`);
+    const scene2 = new Scene(`Scene 2`);
+    this._scenes = [scene, scene2];
+    this._scene = scene;
+    this._cameras = [scene.camera];
+    this._camera = scene.camera;
+
+    // 새로운 DOM 요소로 controls 재생성
+    this._persepectiveControls = new PerspectiveControls(
+      this._scene.camera as THREE.PerspectiveCamera,
+      this._dom!,
+    );
+
+    this._orthographicControls = new OrthographicControls(
+      this._scene.camera as THREE.OrthographicCamera,
+      this._dom!,
+    );
+
+    this._controls = this._persepectiveControls;
+
+    this._viewHelper = new ViewHelper(
+      this._camera as THREE.PerspectiveCamera | THREE.OrthographicCamera,
+      dom,
+    );
+
+    this._renderer.setAnimationLoop(() => this.render());
+  }
+
+  public static getInstance(): Context {
+    if (!Context.instance) {
+      Context.instance = new Context();
+    }
+    return Context.instance;
+  }
+
+  get renderer() {
+    return this._renderer;
+  }
+
+  get dom() {
+    if (!this._dom) {
+      throw new Error("DOM is not initialized");
+    }
+    return this._dom;
+  }
+
+  set dom(dom: HTMLDivElement | null) {
+    this._dom = dom;
+  }
+
+  public addScene(scene: Scene) {
+    this._scenes = [...this._scenes, scene];
+  }
+  get scenes() {
+    return this._scenes;
+  }
+
+  get transformControls() {
+    if (!this._transformControls) {
+      throw new Error("TransformControls is not initialized");
+    }
+    return this._transformControls;
+  }
+  set transformControls(transformControls: TransformControls) {
+    this._transformControls = transformControls;
+  }
+
+  get scene(): Scene | null {
+    if (!this._scene) {
+      return null;
+    }
+    return this._scene;
+  }
+
+  set controls(controls: PerspectiveControls | OrthographicControls) {
+    this._controls = controls;
+  }
+
+  get persepectiveControls() {
+    if (!this._persepectiveControls) {
+      throw new Error("PerspectiveControls is not initialized");
+    }
+    return this._persepectiveControls;
+  }
+
+  get orthographicControls() {
+    if (!this._orthographicControls) {
+      throw new Error("OrthographicControls is not initialized");
+    }
+    return this._orthographicControls;
+  }
+
+  public updateControls(camera: THREE.Camera) {
+    this._persepectiveControls!.enabled = true;
+    this._orthographicControls!.enabled = false;
+    if (camera instanceof THREE.PerspectiveCamera) {
+      this._controls = this._persepectiveControls;
+
+      this._camera = camera;
+      this._persepectiveControls?.updateCamera(camera);
+    } else if (camera instanceof THREE.OrthographicCamera) {
+      this._persepectiveControls!.enabled = false;
+      this._orthographicControls!.enabled = true;
+      this._controls = this._orthographicControls;
+      this._camera = camera;
+      this._orthographicControls?.updateCamera(camera);
+    }
+  }
+
+  set scene(scene: Scene) {
+    console.log("%cchange Scene", "color: orange;");
+    this._scene = scene;
+    this._camera = scene.camera;
+
+    // 카메라 타입에 따라 적절한 컨트롤러 설정
+    this.updateControls(scene.camera);
+
+    this._transformControls?.dispose();
+    this._transformControls = new TransformControls(this._scene!.camera, this._dom!);
+    this._camera = this._scene!.camera;
+
+    this.notify();
+  }
+
+  get cameras() {
+    return this._cameras;
+  }
+
+  set cameras(cameras: THREE.Camera[]) {
+    this._cameras = [...this._cameras, ...cameras];
+  }
+
+  get viewHelper() {
+    if (!this._viewHelper) {
+      throw new Error("ViewHelper is not initialized");
+    }
+    return this._viewHelper;
+  }
+
+  set viewHelper(viewHelper: ViewHelper) {
+    this._viewHelper = viewHelper;
+  }
+
+  get camera() {
+    if (!this._camera) {
+      throw new Error("Camera is not initialized");
+    }
+    return this._camera;
+  }
+
+  set camera(camera: THREE.Camera) {
+    this._camera = camera;
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  set id(id: number) {
+    this._id = id;
+  }
+
+  public subscribe(listener: () => void) {
+    this._listeners = [...this._listeners, listener];
+  }
+  public unsubscribe(listener: () => void) {
+    this._listeners = this._listeners.filter((l) => l !== listener);
+  }
+  public notify() {
+    this._listeners.forEach((listener) => listener());
+  }
+
+  public resize() {
+    if (!this._scene) {
+      throw new Error("Scene is not initialized");
+    } else {
+      this._renderer.setSize(this._dom!.clientWidth, this._dom!.clientHeight);
+      const perspectiveCamera = this._scene.camera as THREE.PerspectiveCamera;
+      perspectiveCamera.aspect = this._dom!.clientWidth / this._dom!.clientHeight;
+      perspectiveCamera.updateProjectionMatrix();
+    }
+    if (this._camera instanceof THREE.OrthographicCamera) {
+      const frustumSize =
+        2 *
+        Math.tan((DEFAULT_CAMERA_SPEC.fov * Math.PI) / 180 / 2) *
+        this._scene.perspectiveCamera.position.z;
+      const aspect = this._dom!.clientWidth / this._dom!.clientHeight;
+
+      this._camera.left = (-frustumSize * aspect) / 2;
+      this._camera.right = (frustumSize * aspect) / 2;
+      this._camera.top = frustumSize / 2;
+      this._camera.bottom = -frustumSize / 2;
+
+      this._camera.updateProjectionMatrix();
+    }
+  }
+
+  public render() {
+    if (!this._scene) {
+      throw new Error("Scene is not initialized");
+    } else {
+      this.resize();
+
+      this._scene!.camera!.updateMatrixWorld();
+
+      this._renderer.autoClear = false;
+      this._renderer.render(this._scene, this._scene.camera);
+
+      this._scene.render();
+
+      this._controls?.render();
+      this._renderer.render(this._scene.sceneHelper, this._scene.camera);
+      this._viewHelper?.render(this._renderer);
+      this._renderer.autoClear = true;
+
+      JEASINGS.update();
+    }
+  }
+
+  public dispose() {
+    this._renderer.dispose();
+    if (this._dom) {
+      while (this._dom.firstChild) {
+        this._dom.removeChild(this._dom.firstChild);
+      }
+    }
+    this._scenes.forEach((scene) => {
+      scene.dispose();
+    });
+    this._scenes = [];
+    this._scene = null;
+    this._cameras = [];
+    this._camera = null;
+    this._controls?.dispose();
+    this._listeners = [];
+  }
+}

--- a/src/core/directional-light.ts
+++ b/src/core/directional-light.ts
@@ -1,0 +1,16 @@
+import * as THREE from "three";
+
+export class DirectionalLight extends THREE.DirectionalLight {
+  private _sceneGraph: THREE.Object3D[] = [];
+  constructor(color: number, intensity: number) {
+    super(color, intensity);
+  }
+
+  get sceneGraph() {
+    return this._sceneGraph;
+  }
+
+  set sceneGraph(sceneGraph: THREE.Object3D[]) {
+    this._sceneGraph = sceneGraph;
+  }
+}

--- a/src/core/grid.ts
+++ b/src/core/grid.ts
@@ -1,0 +1,199 @@
+import * as THREE from "three";
+import { RGB_COLOR, GRID_COLOR } from "../constants/color";
+import {} from "../constants/color";
+
+export class Grid extends THREE.Group {
+  type: string;
+
+  private readonly gridXY: THREE.GridHelper; // XY 평면
+  private readonly gridXZ: THREE.GridHelper; // ZX 평면
+  private readonly gridYZ: THREE.GridHelper; // YZ 평면
+  opacity: number = 0.5;
+  constructor(size: number, divisions: number) {
+    super();
+    this.type = "GridHelper";
+    this.gridXZ = this.createGrid(
+      size,
+      divisions,
+      this.opacity,
+      new THREE.Color(RGB_COLOR.r),
+      new THREE.Color(RGB_COLOR.b)
+    );
+    this.add(this.gridXZ);
+
+    this.gridXY = this.createGrid(
+      1,
+      1,
+      this.opacity,
+      new THREE.Color(RGB_COLOR.r),
+      new THREE.Color(RGB_COLOR.b)
+    );
+    this.gridXY.rotation.x = Math.PI / 2;
+    // this.add(this.gridXY);
+
+    this.gridYZ = this.createGrid(
+      size,
+      2,
+      this.opacity,
+      new THREE.Color(RGB_COLOR.g),
+      new THREE.Color(RGB_COLOR.r)
+    );
+    this.gridYZ.rotation.z = Math.PI / 2;
+    // this.add(this.gridYZ);
+  }
+
+  private createGrid(
+    size: number,
+    divisions: number,
+    opacity: number = 0.5,
+    color1: THREE.Color,
+    color2: THREE.Color,
+    normalColor = new THREE.Color(GRID_COLOR)
+  ) {
+    // Make it transparent
+    const grid = new THREE.GridHelper(size, divisions);
+    grid.material.opacity = opacity;
+    grid.material.transparent = true;
+
+    // Modify geometry to set different colors for center lines
+    const gridGeometry = grid.geometry;
+    const positionAttr = gridGeometry.getAttribute("position");
+
+    const colorAttr = new THREE.BufferAttribute(
+      new Float32Array(positionAttr.count * 3),
+      3
+    );
+
+    const colorNormal = normalColor;
+
+    for (let i = 0; i < positionAttr.count; i++) {
+      let x = positionAttr.getX(i);
+      let z = positionAttr.getZ(i);
+
+      if (z === 0) {
+        color1.toArray(colorAttr.array, i * 3);
+      } else if (x === 0) {
+        color2.toArray(colorAttr.array, i * 3);
+      } else {
+        colorNormal.toArray(colorAttr.array, i * 3);
+      }
+    }
+    gridGeometry.setAttribute("color", colorAttr);
+    grid.material.vertexColors = true;
+    grid.frustumCulled = false;
+    return grid;
+  }
+  public setOpacity(opacity: number): void {
+    this.gridXY.material.opacity = opacity;
+    this.gridXZ.material.opacity = opacity;
+    this.gridYZ.material.opacity = opacity;
+  }
+
+  public showGridXY() {
+    this.gridXY.visible = true;
+    this.gridXZ.visible = false;
+    this.gridYZ.visible = false;
+  }
+
+  public showGridXZ() {
+    this.gridXY.visible = false;
+    this.gridXZ.visible = true;
+    this.gridYZ.visible = false;
+  }
+
+  public showGridYZ() {
+    this.gridXY.visible = false;
+    this.gridXZ.visible = false;
+    this.gridYZ.visible = true;
+  }
+
+  public showAllGrid() {
+    this.gridXY.visible = true;
+    this.gridXZ.visible = true;
+    this.gridYZ.visible = true;
+  }
+
+  public hiddenAllGrid() {
+    this.gridXY.visible = false;
+    this.gridXZ.visible = false;
+    this.gridYZ.visible = false;
+  }
+
+  public update(camera: THREE.Camera): void {
+    if (!camera) {
+      return;
+    }
+
+    // 카메라의 방향 벡터 계산
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+
+    // 카메라 위치에서 방향 벡터를 따라가는 광선 생성
+    const raycaster = new THREE.Raycaster(camera.position, direction, 0.1, 100);
+
+    // 그리드 평면과의 교점 계산
+    const planeXY = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+    const planeXZ = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+    const planeYZ = new THREE.Plane(new THREE.Vector3(1, 0, 0), 0);
+
+    const intersectXY = raycaster.ray.intersectPlane(
+      planeXY,
+      new THREE.Vector3()
+    );
+    const intersectXZ = raycaster.ray.intersectPlane(
+      planeXZ,
+      new THREE.Vector3()
+    );
+    const intersectYZ = raycaster.ray.intersectPlane(
+      planeYZ,
+      new THREE.Vector3()
+    );
+
+    // 교점 거리 계산
+    const distanceXY = intersectXY
+      ? camera.position.distanceTo(intersectXY)
+      : 0;
+    const distanceXZ = intersectXZ
+      ? camera.position.distanceTo(intersectXZ)
+      : 0;
+    const distanceYZ = intersectYZ
+      ? camera.position.distanceTo(intersectYZ)
+      : 0;
+
+    // 거리 기반으로 scale 계산
+    const scaleXY = this.getScaleByDistance(distanceXY);
+    const scaleXZ = this.getScaleByDistance(distanceXZ);
+    const scaleYZ = this.getScaleByDistance(distanceYZ);
+
+    // 그리드의 scale 적용
+    this.gridXY.scale.set(scaleXY, scaleXY, scaleXY);
+    this.gridXZ.scale.set(scaleXZ, scaleXZ, scaleXZ);
+    this.gridYZ.scale.set(scaleYZ, scaleYZ, scaleYZ);
+  }
+
+  private getScaleByDistance(distance: number): number {
+    if (distance < 1) {
+      return 0.5;
+    } else if (distance < 20) {
+      return 2;
+    } else if (distance < 50) {
+      return 4;
+    } else if (distance < 100) {
+      return 8;
+    } else if (distance < 200) {
+      return 16;
+    } else if (distance < 300) {
+      return 32;
+    } else if (distance < 400) {
+      return 32;
+    } else {
+      return Math.trunc(distance / 10);
+    }
+  }
+
+  public dispose(): void {
+    this.gridXY.dispose();
+    this.gridXZ.dispose();
+    this.gridYZ.dispose();
+  }
+}

--- a/src/core/group.ts
+++ b/src/core/group.ts
@@ -1,0 +1,15 @@
+import * as THREE from "three";
+
+export class Group extends THREE.Group {
+  constructor() {
+    super();
+  }
+
+  addObject(object: THREE.Object3D) {
+    super.add(object);
+  }
+
+  attachObject(object: THREE.Object3D) {
+    super.attach(object);
+  }
+}

--- a/src/core/mesh.ts
+++ b/src/core/mesh.ts
@@ -1,0 +1,54 @@
+import * as THREE from "three";
+import { MeshType } from "../types/mesh";
+
+declare module "three" {
+  interface Object3D {
+    sceneGraph: THREE.Object3D[];
+  }
+  interface Mesh {
+    sceneGraph: THREE.Object3D[];
+  }
+}
+
+export const createMesh = (type: MeshType): THREE.Mesh | THREE.Group => {
+  if (type === "Group") {
+    const mesh: THREE.Group = new THREE.Group();
+    mesh.name = `New Group`;
+    mesh["sceneGraph"] = [];
+
+    return mesh;
+  }
+  const mesh: THREE.Mesh = new THREE.Mesh();
+  mesh["sceneGraph"] = [];
+
+  const geometry = createGeometry(type);
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(0xffffff),
+  });
+  mesh.geometry = geometry;
+  mesh.material = material;
+  mesh.position.set(0, 0, 0);
+
+  mesh.name = `New ${type}`;
+
+  return mesh;
+};
+
+const createGeometry = (type: MeshType): THREE.BufferGeometry => {
+  switch (type) {
+    case "Box":
+      return new THREE.BoxGeometry(1, 1, 1);
+    case "Plane":
+      return new THREE.PlaneGeometry(1, 1);
+    case "Sphere":
+      return new THREE.SphereGeometry(1, 32, 16);
+    case "Cylinder":
+      return new THREE.CylinderGeometry(0.5, 0.5, 1, 32);
+    case "Cone":
+      return new THREE.ConeGeometry(0.5, 1, 32);
+    case "Torus":
+      return new THREE.TorusGeometry(0.5, 0.2, 16, 64);
+    default:
+      return new THREE.BoxGeometry(1, 1, 1);
+  }
+};

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -1,0 +1,23 @@
+import * as THREE from "three";
+
+export class Object3D extends THREE.Object3D {
+  private _sceneGraph: THREE.Object3D[] = [];
+  constructor() {
+    super();
+    this._sceneGraph = [];
+  }
+  addObject(object: THREE.Object3D, update: boolean = true) {
+    super.add(object);
+    if (update) {
+      this.updateSceneGraph();
+    }
+  }
+
+  get sceneGraph() {
+    return this._sceneGraph;
+  }
+
+  updateSceneGraph() {
+    this._sceneGraph = [...this.children];
+  }
+}

--- a/src/core/orthographic-controls.ts
+++ b/src/core/orthographic-controls.ts
@@ -28,16 +28,8 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
   private domElement: HTMLElement;
   // touch
   private prevDistance: number | null = null;
-  private touches = [
-    new THREE.Vector3(),
-    new THREE.Vector3(),
-    new THREE.Vector3(),
-  ];
-  private prevTouches = [
-    new THREE.Vector3(),
-    new THREE.Vector3(),
-    new THREE.Vector3(),
-  ];
+  private touches = [new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3()];
+  private prevTouches = [new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3()];
 
   constructor(camera: THREE.OrthographicCamera, domElement: HTMLElement) {
     super();
@@ -67,7 +59,6 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
     if (this.enabled === false) return;
     let distance: number;
     this.box.setFromObject(target, false);
-    console.log("focus box : ", this.box);
 
     if (this.box.isEmpty() === false) {
       this.box.getCenter(this.center);
@@ -96,7 +87,7 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
     delta.applyMatrix3(this.normalMatrix.getNormalMatrix(this.camera.matrix));
 
     this.camera.position.add(delta);
-    console.log(this.camera.position);
+
     this.center.add(delta);
     this.dispatchEvent({ type: "change" });
   }
@@ -104,10 +95,7 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
   private zoom(delta: THREE.Vector3): void {
     if (this.enabled === false) return;
     const zoomChange = delta.z < 0 ? 0.008 : -0.008;
-    this.camera.zoom = Math.max(
-      0.02,
-      Math.min(0.9, this.camera.zoom + zoomChange)
-    );
+    this.camera.zoom = Math.max(0.02, Math.min(0.9, this.camera.zoom + zoomChange));
     this.camera.updateProjectionMatrix();
     this.dispatchEvent({ type: "change" });
   }
@@ -118,14 +106,8 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
 
     if (this.pointers.length === 0) {
       this.domElement.setPointerCapture(event.pointerId);
-      this.domElement.ownerDocument.addEventListener(
-        "pointermove",
-        this.onPointerMove
-      );
-      this.domElement.ownerDocument.addEventListener(
-        "pointerup",
-        this.onPointerUp
-      );
+      this.domElement.ownerDocument.addEventListener("pointermove", this.onPointerMove);
+      this.domElement.ownerDocument.addEventListener("pointerup", this.onPointerUp);
     }
 
     if (this.isTrackingPointer(event)) return;
@@ -153,14 +135,8 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
       case 0:
         this.domElement.releasePointerCapture(event.pointerId);
 
-        this.domElement.ownerDocument.removeEventListener(
-          "pointermove",
-          this.onPointerMove
-        );
-        this.domElement.ownerDocument.removeEventListener(
-          "pointerup",
-          this.onPointerUp
-        );
+        this.domElement.ownerDocument.removeEventListener("pointermove", this.onPointerMove);
+        this.domElement.ownerDocument.removeEventListener("pointerup", this.onPointerUp);
 
         break;
 
@@ -198,7 +174,6 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
     const movementX = this.pointer.x - this.pointerOld.x;
     const movementY = this.pointer.y - this.pointerOld.y;
 
-    console.log(this);
     if (this.state === this.STATE.ZOOM) {
       this.zoom(this.delta.set(0, 0, movementY));
     } else if (this.state === this.STATE.PAN) {
@@ -216,7 +191,7 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
     // event.preventDefault();
 
     // Normalize deltaY due to https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
-    console.log(this);
+
     this.zoom(this.delta.set(0, 0, event.deltaY > 0 ? 1 : -1));
   }
   private contextmenu(event: MouseEvent): void {
@@ -243,23 +218,15 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
 
     switch (this.pointers.length) {
       case 1:
-        this.touches[0]
-          .set(event.pageX, event.pageY, 0)
-          .divideScalar(window.devicePixelRatio);
-        this.touches[1]
-          .set(event.pageX, event.pageY, 0)
-          .divideScalar(window.devicePixelRatio);
+        this.touches[0].set(event.pageX, event.pageY, 0).divideScalar(window.devicePixelRatio);
+        this.touches[1].set(event.pageX, event.pageY, 0).divideScalar(window.devicePixelRatio);
         break;
 
       case 2: {
         const position = this.getSecondPointerPosition(event);
 
-        this.touches[0]
-          .set(event.pageX, event.pageY, 0)
-          .divideScalar(window.devicePixelRatio);
-        this.touches[1]
-          .set(position.x, position.y, 0)
-          .divideScalar(window.devicePixelRatio);
+        this.touches[0].set(event.pageX, event.pageY, 0).divideScalar(window.devicePixelRatio);
+        this.touches[1].set(position.x, position.y, 0).divideScalar(window.devicePixelRatio);
         this.prevDistance = this.touches[0].distanceTo(this.touches[1]);
         break;
       }
@@ -276,8 +243,7 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
       let closest = touches[0];
 
       for (const touch2 of touches) {
-        if (closest.distanceTo(touch) > touch2.distanceTo(touch))
-          closest = touch2;
+        if (closest.distanceTo(touch) > touch2.distanceTo(touch)) closest = touch2;
       }
 
       return closest;
@@ -285,33 +251,21 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
 
     switch (this.pointers.length) {
       case 1:
-        this.touches[0]
-          .set(event.pageX, event.pageY, 0)
-          .divideScalar(window.devicePixelRatio);
-        this.touches[1]
-          .set(event.pageX, event.pageY, 0)
-          .divideScalar(window.devicePixelRatio);
+        this.touches[0].set(event.pageX, event.pageY, 0).divideScalar(window.devicePixelRatio);
+        this.touches[1].set(event.pageX, event.pageY, 0).divideScalar(window.devicePixelRatio);
         break;
 
       case 2: {
         const position = this.getSecondPointerPosition(event);
 
-        this.touches[0]
-          .set(event.pageX, event.pageY, 0)
-          .divideScalar(window.devicePixelRatio);
-        this.touches[1]
-          .set(position.x, position.y, 0)
-          .divideScalar(window.devicePixelRatio);
+        this.touches[0].set(event.pageX, event.pageY, 0).divideScalar(window.devicePixelRatio);
+        this.touches[1].set(position.x, position.y, 0).divideScalar(window.devicePixelRatio);
         const distance = this.touches[0].distanceTo(this.touches[1]);
         this.zoom(this.delta.set(0, 0, this.prevDistance ?? 0 - distance));
         this.prevDistance = distance;
 
-        const offset0 = this.touches[0]
-          .clone()
-          .sub(getClosest(this.touches[0], this.prevTouches));
-        const offset1 = this.touches[1]
-          .clone()
-          .sub(getClosest(this.touches[1], this.prevTouches));
+        const offset0 = this.touches[0].clone().sub(getClosest(this.touches[0], this.prevTouches));
+        const offset1 = this.touches[1].clone().sub(getClosest(this.touches[1], this.prevTouches));
         offset0.x = -offset0.x;
         offset1.x = -offset1.x;
 
@@ -358,10 +312,7 @@ export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEv
   }
   private getSecondPointerPosition(event): THREE.Vector2 {
     if (this.enabled === false) return new THREE.Vector2();
-    const pointerId =
-      event.pointerId === this.pointers[0]
-        ? this.pointers[1]
-        : this.pointers[0];
+    const pointerId = event.pointerId === this.pointers[0] ? this.pointers[1] : this.pointers[0];
     return this.pointerPositions[pointerId];
   }
 

--- a/src/core/orthographic-controls.ts
+++ b/src/core/orthographic-controls.ts
@@ -1,0 +1,371 @@
+import * as THREE from "three";
+
+interface EditorControlsEvent {
+  change: { message?: string };
+}
+export class OrthographicControls extends THREE.EventDispatcher<EditorControlsEvent> {
+  public enabled = false;
+  public center = new THREE.Vector3();
+  public panSpeed = 0.002;
+  public zoomSpeed = 0.1;
+
+  public camera: THREE.OrthographicCamera;
+
+  private delta = new THREE.Vector3();
+  private box = new THREE.Box3();
+
+  private STATE = { NONE: -1, ZOOM: 0, PAN: 1 } as const;
+  private state: number = this.STATE.NONE;
+
+  private normalMatrix = new THREE.Matrix3();
+  private pointer = new THREE.Vector2();
+  private pointerOld = new THREE.Vector2();
+  private sphere = new THREE.Sphere();
+
+  private pointers: Array<number> = [];
+  private pointerPositions: Record<number, THREE.Vector2> = {};
+
+  private domElement: HTMLElement;
+  // touch
+  private prevDistance: number | null = null;
+  private touches = [
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+  ];
+  private prevTouches = [
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+  ];
+
+  constructor(camera: THREE.OrthographicCamera, domElement: HTMLElement) {
+    super();
+    this.camera = camera;
+    this.domElement = domElement;
+
+    this.contextmenu = this.contextmenu.bind(this);
+    this.onMouseUp = this.onMouseUp.bind(this);
+    this.onMouseWheel = this.onMouseWheel.bind(this);
+    this.onPointerDown = this.onPointerDown.bind(this);
+    this.onPointerMove = this.onPointerMove.bind(this);
+    this.onPointerUp = this.onPointerUp.bind(this);
+
+    domElement.addEventListener("contextmenu", this.contextmenu);
+    domElement.addEventListener("dblclick", this.onMouseUp);
+    domElement.addEventListener("wheel", this.onMouseWheel, {
+      passive: false,
+    });
+    domElement.addEventListener("pointerdown", this.onPointerDown);
+  }
+
+  public updateCamera(camera: THREE.OrthographicCamera) {
+    this.camera = camera;
+  }
+
+  public focus(target: THREE.Object3D): void {
+    if (this.enabled === false) return;
+    let distance: number;
+    this.box.setFromObject(target, false);
+    console.log("focus box : ", this.box);
+
+    if (this.box.isEmpty() === false) {
+      this.box.getCenter(this.center);
+      distance = this.box.getBoundingSphere(this.sphere).radius;
+    } else {
+      // Focusing on an Group, AmbientLight, etc
+      this.center.setFromMatrixPosition(target.matrixWorld);
+      distance = 0.1;
+    }
+
+    this.delta.set(0, 0, 1);
+    this.delta.applyQuaternion(this.camera.quaternion);
+    this.delta.multiplyScalar(distance * 4);
+    this.camera.position.copy(this.center).add(this.delta);
+
+    this.dispatchEvent({ type: "change" });
+  }
+
+  private pan(delta: THREE.Vector3): void {
+    if (this.enabled === false) return;
+
+    const distance = this.camera.position.distanceTo(this.center);
+    const cameraZoom = this.camera.zoom * 1.5;
+
+    delta.multiplyScalar((distance * this.panSpeed) / cameraZoom);
+    delta.applyMatrix3(this.normalMatrix.getNormalMatrix(this.camera.matrix));
+
+    this.camera.position.add(delta);
+    console.log(this.camera.position);
+    this.center.add(delta);
+    this.dispatchEvent({ type: "change" });
+  }
+
+  private zoom(delta: THREE.Vector3): void {
+    if (this.enabled === false) return;
+    const zoomChange = delta.z < 0 ? 0.008 : -0.008;
+    this.camera.zoom = Math.max(
+      0.02,
+      Math.min(0.9, this.camera.zoom + zoomChange)
+    );
+    this.camera.updateProjectionMatrix();
+    this.dispatchEvent({ type: "change" });
+  }
+
+  // pointer
+  private onPointerDown(event: PointerEvent): void {
+    if (this.enabled === false) return;
+
+    if (this.pointers.length === 0) {
+      this.domElement.setPointerCapture(event.pointerId);
+      this.domElement.ownerDocument.addEventListener(
+        "pointermove",
+        this.onPointerMove
+      );
+      this.domElement.ownerDocument.addEventListener(
+        "pointerup",
+        this.onPointerUp
+      );
+    }
+
+    if (this.isTrackingPointer(event)) return;
+    this.addPointer(event);
+
+    if (event.pointerType === "touch") {
+      this.onTouchStart(event);
+    } else {
+      this.onMouseDown(event);
+    }
+  }
+  private onPointerMove(event: PointerEvent): void {
+    if (this.enabled === false) return;
+
+    if (event.pointerType === "touch") {
+      this.onTouchMove(event);
+    } else {
+      this.onMouseMove(event);
+    }
+  }
+  private onPointerUp(event: PointerEvent): void {
+    this.removePointer(event);
+
+    switch (this.pointers.length) {
+      case 0:
+        this.domElement.releasePointerCapture(event.pointerId);
+
+        this.domElement.ownerDocument.removeEventListener(
+          "pointermove",
+          this.onPointerMove
+        );
+        this.domElement.ownerDocument.removeEventListener(
+          "pointerup",
+          this.onPointerUp
+        );
+
+        break;
+
+      case 1: {
+        const pointerId = this.pointers[0];
+        const position = this.pointerPositions[pointerId];
+        // minimal placeholder event - allows state correction on pointer-up
+        this.onTouchStart({
+          pointerId: pointerId,
+          pageX: position.x,
+          pageY: position.y,
+        });
+        break;
+      }
+    }
+  }
+
+  // mouse
+  private onMouseDown(event: MouseEvent): void {
+    if (this.enabled === false) return;
+    if (event.button === 0) {
+      //
+    } else if (event.button === 1) {
+      this.state = this.STATE.ZOOM;
+    } else if (event.button === 2) {
+      this.state = this.STATE.PAN;
+    }
+    this.pointerOld.set(event.clientX, event.clientY);
+  }
+
+  private onMouseMove(event: MouseEvent): void {
+    if (this.enabled === false) return;
+    this.pointer.set(event.clientX, event.clientY);
+
+    const movementX = this.pointer.x - this.pointerOld.x;
+    const movementY = this.pointer.y - this.pointerOld.y;
+
+    console.log(this);
+    if (this.state === this.STATE.ZOOM) {
+      this.zoom(this.delta.set(0, 0, movementY));
+    } else if (this.state === this.STATE.PAN) {
+      this.pan(this.delta.set(-movementX, movementY, 0));
+    }
+
+    this.pointerOld.set(event.clientX, event.clientY);
+  }
+  private onMouseUp(): void {
+    this.state = this.STATE.NONE;
+  }
+  private onMouseWheel(event: WheelEvent): void {
+    if (this.enabled === false) return;
+
+    // event.preventDefault();
+
+    // Normalize deltaY due to https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
+    console.log(this);
+    this.zoom(this.delta.set(0, 0, event.deltaY > 0 ? 1 : -1));
+  }
+  private contextmenu(event: MouseEvent): void {
+    event.preventDefault();
+  }
+
+  public connect() {
+    this.domElement.addEventListener("contextmenu", this.contextmenu);
+    this.domElement.addEventListener("dblclick", this.onMouseUp);
+    this.domElement.addEventListener("wheel", this.onMouseWheel);
+    this.domElement.addEventListener("pointerdown", this.onPointerDown);
+  }
+
+  public dispose(): void {
+    this.domElement.removeEventListener("contextmenu", this.contextmenu);
+    this.domElement.removeEventListener("dblclick", this.onMouseUp);
+    this.domElement.removeEventListener("wheel", this.onMouseWheel);
+    this.domElement.removeEventListener("pointerdown", this.onPointerDown);
+  }
+
+  private onTouchStart(event): void {
+    if (this.enabled === false) return;
+    this.trackPointer(event);
+
+    switch (this.pointers.length) {
+      case 1:
+        this.touches[0]
+          .set(event.pageX, event.pageY, 0)
+          .divideScalar(window.devicePixelRatio);
+        this.touches[1]
+          .set(event.pageX, event.pageY, 0)
+          .divideScalar(window.devicePixelRatio);
+        break;
+
+      case 2: {
+        const position = this.getSecondPointerPosition(event);
+
+        this.touches[0]
+          .set(event.pageX, event.pageY, 0)
+          .divideScalar(window.devicePixelRatio);
+        this.touches[1]
+          .set(position.x, position.y, 0)
+          .divideScalar(window.devicePixelRatio);
+        this.prevDistance = this.touches[0].distanceTo(this.touches[1]);
+        break;
+      }
+    }
+
+    this.prevTouches[0].copy(this.touches[0]);
+    this.prevTouches[1].copy(this.touches[1]);
+  }
+  private onTouchMove(event): void {
+    if (this.enabled === false) return;
+    this.trackPointer(event);
+
+    function getClosest(touch, touches: THREE.Vector3[]): THREE.Vector3 {
+      let closest = touches[0];
+
+      for (const touch2 of touches) {
+        if (closest.distanceTo(touch) > touch2.distanceTo(touch))
+          closest = touch2;
+      }
+
+      return closest;
+    }
+
+    switch (this.pointers.length) {
+      case 1:
+        this.touches[0]
+          .set(event.pageX, event.pageY, 0)
+          .divideScalar(window.devicePixelRatio);
+        this.touches[1]
+          .set(event.pageX, event.pageY, 0)
+          .divideScalar(window.devicePixelRatio);
+        break;
+
+      case 2: {
+        const position = this.getSecondPointerPosition(event);
+
+        this.touches[0]
+          .set(event.pageX, event.pageY, 0)
+          .divideScalar(window.devicePixelRatio);
+        this.touches[1]
+          .set(position.x, position.y, 0)
+          .divideScalar(window.devicePixelRatio);
+        const distance = this.touches[0].distanceTo(this.touches[1]);
+        this.zoom(this.delta.set(0, 0, this.prevDistance ?? 0 - distance));
+        this.prevDistance = distance;
+
+        const offset0 = this.touches[0]
+          .clone()
+          .sub(getClosest(this.touches[0], this.prevTouches));
+        const offset1 = this.touches[1]
+          .clone()
+          .sub(getClosest(this.touches[1], this.prevTouches));
+        offset0.x = -offset0.x;
+        offset1.x = -offset1.x;
+
+        this.pan(offset0.add(offset1));
+
+        break;
+      }
+    }
+
+    this.prevTouches[0].copy(this.touches[0]);
+    this.prevTouches[1].copy(this.touches[1]);
+  }
+  private addPointer(event): void {
+    if (this.enabled === false) return;
+    this.pointers.push(event.pointerId);
+  }
+  private removePointer(event): void {
+    if (this.enabled === false) return;
+    delete this.pointerPositions[event.pointerId];
+
+    for (let i = 0; i < this.pointers.length; i++) {
+      if (this.pointers[i] == event.pointerId) {
+        this.pointers.splice(i, 1);
+        return;
+      }
+    }
+  }
+  private isTrackingPointer(event): boolean {
+    if (this.enabled === false) return false;
+    for (let i = 0; i < this.pointers.length; i++) {
+      if (this.pointers[i] == event.pointerId) return true;
+    }
+    return false;
+  }
+  private trackPointer(event): void {
+    if (this.enabled === false) return;
+    let position = this.pointerPositions[event.pointerId];
+    if (position === undefined) {
+      position = new THREE.Vector2();
+      this.pointerPositions[event.pointerId] = position;
+    }
+
+    position.set(event.pageX, event.pageY);
+  }
+  private getSecondPointerPosition(event): THREE.Vector2 {
+    if (this.enabled === false) return new THREE.Vector2();
+    const pointerId =
+      event.pointerId === this.pointers[0]
+        ? this.pointers[1]
+        : this.pointers[0];
+    return this.pointerPositions[pointerId];
+  }
+
+  public render = () => {
+    this.camera.updateProjectionMatrix();
+  };
+}

--- a/src/core/perspective-controls.ts
+++ b/src/core/perspective-controls.ts
@@ -1,0 +1,489 @@
+import * as THREE from "three";
+import { Camera } from "three";
+import { PointerLockControls } from "three/addons/controls/PointerLockControls.js";
+import {
+  CONTROLS_SPEED,
+  MICRO_SECOND,
+  MOUSE_LEFT,
+  MOUSE_MOVE_THRESHOLD,
+  MOUSE_RIGHT,
+  MOUSE_WHEEL,
+  PAN_SPEED,
+} from "../constants/controls";
+import pointerlock from "../assets/controls/pointerlock.svg";
+import { Context } from "./context";
+
+export interface ControlsEvent {
+  change: { message?: string };
+}
+
+export class PerspectiveControls extends THREE.EventDispatcher<ControlsEvent> {
+  private _controls: PointerLockControls | null = null;
+  public enabled: boolean = true;
+  private _dom!: HTMLElement;
+  private _camera!: THREE.PerspectiveCamera;
+
+  // 키보드 방향 관련 상태 변수
+  private _moveForward: boolean = false;
+  private _moveBackward: boolean = false;
+  private _moveLeft: boolean = false;
+  private _moveRight: boolean = false;
+  private _moveUp: boolean = false;
+  private _moveDown: boolean = false;
+  private _slowDown: boolean = false;
+
+  // 이동 관련 변수
+  private _prevTime: number = 0;
+  private _velocity: THREE.Vector3 = new THREE.Vector3();
+  private _direction: THREE.Vector3 = new THREE.Vector3();
+
+  // 포커스 관련 변수
+  private box = new THREE.Box3();
+  private center = new THREE.Vector3();
+  private sphere = new THREE.Sphere();
+
+  // 드래그를 통한 Controls Lock 감지 변수
+  private _pointerLockImage: HTMLImageElement = new Image();
+  private _dragging: boolean = false;
+  private _dragStart: { x: number; y: number } = { x: 0, y: 0 };
+  private _dragEnd: { x: number; y: number } = { x: 0, y: 0 };
+
+  private _active_pointer_left: boolean = false;
+  private _active_pointer_right: boolean = false;
+  private _active_mouse_wheel: boolean = false;
+
+  constructor(camera: THREE.PerspectiveCamera, dom: HTMLElement) {
+    super();
+    // if (PerspectiveControls.instance) {
+    //   return PerspectiveControls.instance;
+    // }
+    // PerspectiveControls.instance = this;
+
+    this._controls = new PointerLockControls(camera, dom);
+    this._dom = dom;
+    this.enabled = true;
+    this._camera = camera;
+
+    this._moveForward = false;
+    this._moveBackward = false;
+    this._moveLeft = false;
+    this._moveRight = false;
+    this._moveUp = false;
+    this._moveDown = false;
+    this._prevTime = 0;
+    this._velocity.set(0, 0, 0);
+    this._direction.set(0, 0, 0);
+
+    this._dragging = false;
+    this._dragStart = { x: 0, y: 0 };
+    this.box = new THREE.Box3();
+
+    this._pointerLockImage.src = pointerlock;
+    this._pointerLockImage.style.width = "30px";
+    this._pointerLockImage.style.height = "30px";
+    this._pointerLockImage.style.position = "absolute";
+
+    // 이벤트 바인딩
+    this.onPointerDown = this.onPointerDown.bind(this);
+    this.onPointerMove = this.onPointerMove.bind(this);
+    this.onPointerUp = this.onPointerUp.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+
+    dom.addEventListener("pointerdown", this.onPointerDown);
+    dom.addEventListener("pointermove", this.onPointerMove);
+    dom.addEventListener("pointerup", this.onPointerUp);
+
+    dom.addEventListener("wheel", this.zoom.bind(this));
+
+    window.addEventListener("keydown", this.focus.bind(this));
+    window.addEventListener("keydown", this.onKeyDown);
+    window.addEventListener("keyup", this.onKeyUp);
+  }
+
+  public static getInstance(): PerspectiveControls {
+    // if (!PerspectiveControls.instance) {
+    //   throw new Error("Controls must be initialized with camera and dom first");
+    // }
+    // return PerspectiveControls.instance;
+  }
+
+  public updateCamera(camera: THREE.PerspectiveCamera) {
+    this._camera = camera;
+    if (this._controls) {
+      this._controls.object = camera;
+    }
+  }
+
+  get moveForward() {
+    return this._moveForward;
+  }
+  get moveBackward() {
+    return this._moveBackward;
+  }
+  get moveLeft() {
+    return this._moveLeft;
+  }
+  get moveRight() {
+    return this._moveRight;
+  }
+
+  get controls() {
+    return this._controls;
+  }
+
+  public init() {
+    // this._moveForward = false;
+    // this._moveBackward = false;
+    // this._moveLeft = false;
+    // this._moveRight = false;
+    // this._prevTime = 0;
+    // this._velocity.set(0, 0, 0);
+    // this._direction.set(0, 0, 0);
+  }
+
+  set enable(enable: boolean) {
+    this.enabled = enable;
+  }
+
+  get enable() {
+    return this.enabled;
+  }
+
+  get camera() {
+    return this._camera;
+  }
+  set camera(camera: THREE.PerspectiveCamera) {
+    this._camera = camera;
+  }
+
+  public zoom(event: WheelEvent): void {
+    if (this.enabled === false) return;
+
+    const context = Context.getInstance();
+    if (this._controls?.object !== context.camera) {
+      return;
+    }
+
+    const direction = new THREE.Vector3();
+    this._controls?.object.getWorldDirection(direction);
+
+    // 카메라와 대상 사이의 거리 계산
+    const cameraPosition = this._controls!.object.position;
+
+    const targetPosition = new THREE.Vector3(0, 0, 0);
+    const distance = cameraPosition.distanceTo(targetPosition);
+
+    const delta = event.deltaY > 0 ? -1 : 1;
+
+    // 거리 비례 이동 거리 설정
+    const moveDistance = distance * 0.1 * delta; // 0.1은 조정 가능한 비율입니다
+
+    this._controls?.object?.position.addScaledVector(direction, moveDistance);
+  }
+
+  public pan(event: MouseEvent): void {
+    const context = Context.getInstance();
+    if (this._controls?.object !== context.camera) {
+      return;
+    }
+    if (this._active_mouse_wheel) {
+      const right = new THREE.Vector3();
+      const up = new THREE.Vector3();
+
+      this._controls?.object.matrix.extractBasis(right, up, new THREE.Vector3());
+
+      // 카메라와 원점 사이의 거리 계산
+      const distance = this._controls!.object.position.length() / 10;
+
+      // 거리 비례 팬 속도 설정
+      const basePanSpeed = PAN_SPEED;
+      const panSpeed = basePanSpeed * (distance || 1); // 거리에 비례하여 팬 속도 조정
+
+      const deltaX = -event.movementX * panSpeed;
+      const deltaY = event.movementY * panSpeed;
+
+      this._controls?.object?.position.addScaledVector(right, deltaX);
+      this._controls?.object?.position.addScaledVector(up, deltaY);
+    }
+  }
+
+  set object(object: THREE.Object3D) {
+    this._controls!.object = object;
+  }
+  public focus(event: KeyboardEvent): void {
+    const target = this._controls?.object;
+
+    if (target === undefined) {
+      return;
+    }
+
+    if (event.code === "KeyF") {
+      let distance: number;
+      this.box.setFromObject(target, false);
+
+      if (this.box.isEmpty() === false) {
+        this.box.getCenter(this.center);
+        distance = this.box.getBoundingSphere(this.sphere).radius;
+      } else {
+        // Focusing on an Group, AmbientLight, etc
+        this.center.setFromMatrixPosition(target.matrixWorld);
+        distance = 0.1;
+      }
+
+      this._velocity.set(0, 0, 1);
+      this._velocity.applyQuaternion(this._camera.quaternion);
+      this._velocity.multiplyScalar(distance * 4);
+      this._camera.position.copy(this.center).add(this._velocity);
+
+      // this.dispatchEvent({ type: "change" });
+    }
+  }
+
+  private onPointerDown(event: MouseEvent) {
+    this.init();
+    document.body.style.cursor = "default";
+    if (this.enabled) {
+      if (event.button === MOUSE_LEFT) {
+        this._active_pointer_left = true;
+        this.onPointerLeftDown(event);
+      } else if (event.button === MOUSE_RIGHT) {
+        this._active_pointer_right = true;
+        this.onPointerRightDown(event);
+      } else if (event.button === MOUSE_WHEEL) {
+        this._active_mouse_wheel = true;
+        this.onMouseWheelDown();
+      }
+    }
+  }
+
+  private onPointerMove(event: MouseEvent) {
+    if (this.enabled === false) return;
+    if (this._active_pointer_left) {
+      this.onPointerLeftMove(event);
+    } else if (this._active_pointer_right) {
+      this.onPointerRightMove(event);
+    } else if (this._active_mouse_wheel) {
+      this.onMouseWheelMove(event);
+    }
+  }
+
+  private onPointerUp(event: MouseEvent) {
+    if (this.enabled === false) return;
+    if (event.button === MOUSE_LEFT) {
+      this._active_pointer_left = false;
+      this.onPointerLeftUp(event);
+    } else if (event.button === MOUSE_RIGHT) {
+      this._active_pointer_right = false;
+      this.onPointerRightUp();
+    } else if (event.button === MOUSE_WHEEL) {
+      this._active_mouse_wheel = false;
+      this.onMouseWheelUp();
+    }
+  }
+  // TODO
+  // LEFT BUTTON 이벤트 처리
+  public onPointerLeftDown(event: MouseEvent) {}
+  public onPointerLeftMove(event: MouseEvent) {}
+  public onPointerLeftUp(event: MouseEvent) {
+    this._active_pointer_left = false;
+  }
+
+  private onPointerRightDown(event: MouseEvent) {
+    if (this.enabled === false) return;
+    this._dragStart = { x: event.clientX, y: event.clientY };
+  }
+  private onPointerRightMove(event: MouseEvent) {
+    if (this.enabled === false) return;
+    if (this._active_pointer_right && !this._dragging) {
+      const deltaX = Math.abs(this._dragStart.x - event.clientX);
+      const deltaY = Math.abs(this._dragStart.y - event.clientY);
+
+      const rect = this._dom.getBoundingClientRect();
+      this._pointerLockImage.style.top = `${event.clientY - rect.top - 15}px`;
+      this._pointerLockImage.style.left = `${event.clientX - rect.left - 15}px`;
+
+      if (deltaX >= MOUSE_MOVE_THRESHOLD || deltaY >= MOUSE_MOVE_THRESHOLD) {
+        this._dragging = true;
+        this._dom.appendChild(this._pointerLockImage);
+      }
+    }
+
+    if (this._dragging) {
+      this._controls?.lock(true);
+    }
+  }
+
+  private onPointerRightUp() {
+    if (this.enabled === false) return;
+
+    // this.init();
+    this._dragging = false;
+    if (this._pointerLockImage.parentElement) {
+      this._dom.removeChild(this._pointerLockImage);
+    }
+    this._controls?.unlock();
+  }
+
+  private onMouseWheelDown() {
+    this._dom.style.cursor = "grab";
+  }
+
+  private onMouseWheelMove(event: MouseEvent) {
+    this._dom.style.cursor = "grabbing";
+    this.pan(event);
+  }
+
+  private onMouseWheelUp() {
+    this._dom.style.cursor = "default";
+    if (this._active_mouse_wheel) {
+      this._active_mouse_wheel = false;
+    }
+  }
+
+  public onKeyDown(event: KeyboardEvent) {
+    if (this.enabled === false) return;
+    switch (event.code) {
+      case "ArrowUp":
+      case "KeyW":
+        this._moveForward = true;
+        break;
+
+      case "ArrowLeft":
+      case "KeyA":
+        this._moveLeft = true;
+        break;
+
+      case "ArrowDown":
+      case "KeyS":
+        this._moveBackward = true;
+        break;
+
+      case "ArrowRight":
+      case "KeyD":
+        this._moveRight = true;
+        break;
+
+      case "Space":
+      case "KeyE":
+        this._moveUp = true;
+        break;
+
+      case "KeyQ":
+        this._moveDown = true;
+        break;
+
+      case "ShiftLeft":
+        this._slowDown = true;
+        break;
+    }
+  }
+  public onKeyUp(event: KeyboardEvent) {
+    if (this.enabled === false) return;
+    switch (event.code) {
+      case "ArrowUp":
+      case "KeyW":
+        this._moveForward = false;
+        break;
+
+      case "ArrowLeft":
+      case "KeyA":
+        this._moveLeft = false;
+        break;
+
+      case "ArrowDown":
+      case "KeyS":
+        this._moveBackward = false;
+        break;
+
+      case "ArrowRight":
+      case "KeyD":
+        this._moveRight = false;
+        break;
+
+      case "Space":
+      case "KeyE":
+        this._moveUp = false;
+        break;
+
+      case "KeyQ":
+        this._moveDown = false;
+        break;
+
+      case "ShiftLeft":
+        this._slowDown = false;
+        break;
+    }
+  }
+
+  public render = () => {
+    if (this.enabled === false) return;
+    if (!this._active_pointer_right) {
+      return;
+    }
+    const time = performance.now();
+
+    const delta = Math.min((time - this._prevTime) / MICRO_SECOND, 0.02);
+
+    this._prevTime = time;
+
+    // if (this._controls?.isLocked === true) {
+    const direction = new THREE.Vector3(0, 0, -1).applyQuaternion(this._camera.quaternion);
+    const right = new THREE.Vector3().crossVectors(direction, new THREE.Vector3(0, 1, 0));
+
+    // 이동 방향 설정
+    const moveForward = Number(this._moveForward);
+    const moveBackward = Number(this._moveBackward);
+    const moveLeft = Number(this._moveLeft);
+    const moveRight = Number(this._moveRight);
+    const moveUp = Number(this._moveUp);
+    const moveDown = Number(this._moveDown);
+
+    // 대각선 이동을 위한 방향 벡터 합산
+    this._velocity.set(0, 0, 0); // 방향 전환 시 즉시 속도 리셋
+    if (moveForward || moveBackward) {
+      this._velocity.addScaledVector(
+        direction,
+        (moveForward - moveBackward) * CONTROLS_SPEED * delta,
+      );
+    }
+    if (moveLeft || moveRight) {
+      this._velocity.addScaledVector(right, (moveRight - moveLeft) * CONTROLS_SPEED * delta);
+    }
+    if (moveUp || moveDown) {
+      this._velocity.addScaledVector(
+        new THREE.Vector3(0, 0.5, 0),
+        (moveUp - moveDown) * CONTROLS_SPEED * delta,
+      );
+    }
+
+    if (this._slowDown) {
+      this._velocity.multiplyScalar(0.1);
+    }
+
+    // 이동 적용
+    if (this._velocity.length() > 0) {
+      this._controls!.object.position.addScaledVector(this._velocity, delta);
+    }
+    // }
+  };
+
+  public connect() {
+    window.addEventListener("keydown", this.focus.bind(this));
+    window.addEventListener("keydown", this.onKeyDown.bind(this));
+    window.addEventListener("keyup", this.onKeyUp.bind(this));
+    this._dom.addEventListener("pointerdown", this.onPointerDown.bind(this));
+    this._dom.addEventListener("pointermove", this.onPointerMove.bind(this));
+    this._dom.addEventListener("pointerup", this.onPointerUp.bind(this));
+    this._dom.addEventListener("wheel", this.zoom.bind(this));
+  }
+  public dispose = () => {
+    window.removeEventListener("keydown", this.focus.bind(this));
+    window.removeEventListener("keydown", this.onKeyDown.bind(this));
+    window.removeEventListener("keyup", this.onKeyUp.bind(this));
+    this._dom.removeEventListener("pointerdown", this.onPointerDown.bind(this));
+    this._dom.removeEventListener("pointermove", this.onPointerMove.bind(this));
+    this._dom.removeEventListener("pointerup", this.onPointerUp.bind(this));
+    this._dom.removeEventListener("wheel", this.zoom.bind(this));
+  };
+}

--- a/src/core/scene.ts
+++ b/src/core/scene.ts
@@ -1,0 +1,359 @@
+import { Context } from "./context";
+import * as THREE from "three";
+
+import {
+  DEFAULT_CAMERA_POSITION,
+  DEFAULT_CAMERA_SPEC,
+  DEFAULT_CAMERA_TARGET,
+} from "../constants/camera";
+import { Grid } from "./grid";
+
+import { TransformControls } from "./transform-controls";
+
+import { createMesh } from "./mesh";
+
+import JEASINGS from "jeasings";
+import { CameraTypes } from "../utils/camera";
+import { SCENE_BACKGROUND_COLOR } from "@/constants/color";
+
+export class Scene extends THREE.Scene {
+  private _sceneGraph: THREE.Object3D[] = [];
+  private _sceneHelper: THREE.Scene;
+  private _camera: CameraTypes;
+  private _perspectiveCamera: THREE.PerspectiveCamera;
+  private _orthographicCamera: THREE.OrthographicCamera;
+  private _originalCamera: THREE.Camera | null = null;
+  private _helpers: Array<THREE.BoxHelper | THREE.DirectionalLightHelper> = [];
+  private _renderer: THREE.WebGLRenderer;
+  private _is2DView: boolean = false;
+  private _transformControls: TransformControls | null = null;
+
+  private _registedCamera: THREE.Camera | null = null;
+  private _selectCamera: THREE.Camera | null = null;
+
+  private _selectedObject: THREE.Object3D[] = [];
+
+  private _listener: (() => void)[] = [];
+
+  constructor(name: string) {
+    super();
+    const context = Context.getInstance();
+    const dom: HTMLDivElement = context.dom!;
+    this._renderer = context.renderer;
+
+    this._is2DView = false;
+    this._sceneGraph = [...this.children];
+    this._sceneHelper = new THREE.Scene();
+
+    this.name = name;
+    this.fog = new THREE.Fog("#1A1E21", 1, 100);
+    this._sceneHelper.fog = new THREE.Fog("#1A1E21", 1, 100);
+    this.fog = new THREE.Fog(SCENE_BACKGROUND_COLOR, 1, 100);
+    this._sceneHelper.fog = new THREE.Fog(SCENE_BACKGROUND_COLOR, 1, 100);
+
+    this._perspectiveCamera = new THREE.PerspectiveCamera(
+      DEFAULT_CAMERA_SPEC.fov,
+      dom.clientWidth / dom.clientHeight,
+      DEFAULT_CAMERA_SPEC.near,
+      DEFAULT_CAMERA_SPEC.far,
+    );
+    this._perspectiveCamera.name = "Perspective Camera";
+    this._perspectiveCamera.position.set(
+      DEFAULT_CAMERA_POSITION.x,
+      DEFAULT_CAMERA_POSITION.y,
+      DEFAULT_CAMERA_POSITION.z,
+    );
+    this._perspectiveCamera.lookAt(
+      DEFAULT_CAMERA_TARGET.x,
+      DEFAULT_CAMERA_TARGET.y,
+      DEFAULT_CAMERA_TARGET.z,
+    );
+
+    this._camera = this._perspectiveCamera;
+
+    const frustumSize =
+      2 *
+      Math.tan((DEFAULT_CAMERA_SPEC.fov * Math.PI) / 180 / 2) *
+      this._perspectiveCamera.position.z;
+    const aspect = dom.clientWidth / dom.clientHeight;
+
+    this._orthographicCamera = new THREE.OrthographicCamera(
+      (-frustumSize * aspect) / 2,
+      (frustumSize * aspect) / 2,
+      frustumSize / 2,
+      -frustumSize / 2,
+      this._perspectiveCamera.near,
+      this._perspectiveCamera.far,
+    );
+    this._orthographicCamera.name = "Orthographic Camera";
+    this._orthographicCamera.position.set(0, 0, 10);
+
+    this.add(this._orthographicCamera);
+
+    this.defaultScene();
+
+    this._transformControls = new TransformControls(this._camera, dom);
+    // this._transformControls.setSpace("local");
+    this._sceneHelper.add(this._transformControls.getHelper());
+
+    // const axesHelper = new THREE.AxesHelper(1000);
+    // axesHelper.setColors(RGB_COLOR.r, RGB_COLOR.g, RGB_COLOR.b);
+    // this.sceneHelper.add(axesHelper);
+    dom.appendChild(this._renderer.domElement);
+  }
+
+  get camera() {
+    return this._camera;
+  }
+
+  get sceneHelper() {
+    return this._sceneHelper;
+  }
+
+  get sceneGraph() {
+    return this._sceneGraph;
+  }
+
+  get originalCamera() {
+    return this._originalCamera;
+  }
+
+  get perspectiveCamera() {
+    return this._perspectiveCamera;
+  }
+
+  get orthographicCamera() {
+    return this._orthographicCamera;
+  }
+
+  set originalCamera(camera: THREE.Camera | null) {
+    this._originalCamera = camera;
+  }
+
+  get transformControls() {
+    return this._transformControls;
+  }
+
+  get registedCamera() {
+    return this._registedCamera;
+  }
+  set registedCamera(camera: THREE.Camera | null) {
+    this._registedCamera = camera;
+  }
+
+  get selectedCamera() {
+    return this._selectCamera;
+  }
+  set selectedCamera(camera: THREE.Camera | null) {
+    this._selectCamera = camera;
+  }
+
+  get is2DView() {
+    return this._is2DView;
+  }
+
+  set is2DView(value: boolean) {
+    this._is2DView = value;
+  }
+
+  get selectedObject(): THREE.Object3D[] {
+    return this._selectedObject;
+  }
+
+  set selectedObject(object: THREE.Object3D[]) {
+    console.log("📢select notify");
+
+    // this.removeObject(this._transformControls?.group as THREE.Group, false);
+
+    // this.attachTransformControls(object);
+    this._transformControls?.detach();
+
+    this._selectedObject = object;
+
+    this.updateSceneGraph();
+    this.notify();
+    // this._transformControls?.attach(object);
+    this._transformControls?.attach(object);
+  }
+
+  public addObject(object: THREE.Object3D, update: boolean = true): this {
+    super.add(object);
+    if (update) {
+      this.updateSceneGraph();
+    }
+
+    return this;
+  }
+
+  public attachObject = (object: THREE.Object3D, update: boolean = false): this => {
+    this.attach(object);
+
+    if (update) {
+      this.updateSceneGraph();
+    }
+
+    return this;
+  };
+
+  public removeObject = (object: THREE.Object3D, update: boolean = true): this => {
+    super.remove(object);
+    if (update) {
+      this.updateSceneGraph();
+    }
+    return this;
+  };
+
+  public updateSceneGraph() {
+    this._sceneGraph = [...this.children];
+
+    // const context = Context.getInstance();
+    // context.notify();
+    this.notify();
+  }
+
+  public defaultScene = () => {
+    const camera = new THREE.PerspectiveCamera(50, 1280 / 720, 0.5, 1000);
+    camera.name = "Perspective Camera";
+    camera.position.set(0, 0, 10);
+    camera.lookAt(0, 0, 0);
+    this.add(camera);
+
+    const cameraHelper = new THREE.CameraHelper(camera);
+    this.sceneHelper.add(cameraHelper);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1.75);
+    light.name = "DirectionalLight";
+    light.position.set(0.7, 3, 1.5);
+
+    this.add(light);
+
+    const lightHelper = new THREE.DirectionalLightHelper(light);
+    this._helpers.push(lightHelper);
+    this._sceneHelper.add(lightHelper);
+
+    const box: THREE.Mesh = createMesh("Box") as THREE.Mesh;
+
+    this.add(box);
+
+    light.target = box;
+
+    const grid = new Grid(1000, 1000);
+    this._sceneHelper.add(grid);
+
+    this.updateSceneGraph();
+  };
+
+  public changeCameraMode = () => {
+    const context = Context.getInstance();
+
+    const position = this._camera.position.clone();
+    const rotation = this._camera.rotation.clone();
+    const up = this._camera.up.clone();
+    if (this._camera instanceof THREE.OrthographicCamera) {
+      console.log("Change Camera To %cPerspectiveCamera", "color: skyblue");
+
+      // Zoom 복원
+      this._perspectiveCamera.zoom = 1 / this._orthographicCamera.zoom;
+      this._perspectiveCamera.updateProjectionMatrix();
+      this._perspectiveCamera.position.copy(position);
+      this._perspectiveCamera.rotation.copy(rotation);
+      this._perspectiveCamera.up.copy(up);
+
+      // 위치 및 회전 유지
+      this._camera = this._perspectiveCamera;
+
+      context.updateControls(this._perspectiveCamera);
+    } else if (this._camera instanceof THREE.PerspectiveCamera) {
+      console.log("Change Camera To %cOrthographicCamera", "color: skyblue");
+      const aspect = this._renderer.domElement.clientWidth / this._renderer.domElement.clientHeight;
+
+      this._perspectiveCamera.aspect = aspect;
+      this._perspectiveCamera.updateProjectionMatrix();
+
+      this._orthographicCamera.left = this._orthographicCamera.bottom * aspect;
+      this._orthographicCamera.right = this._orthographicCamera.top * aspect;
+
+      this._orthographicCamera.position.copy(this._camera.position);
+      this._orthographicCamera.rotation.copy(this._camera.rotation);
+      this._orthographicCamera.up.copy(this._camera.up);
+
+      this._camera = this._orthographicCamera;
+
+      context.updateControls(this._orthographicCamera);
+    }
+
+    context.viewHelper.camera = this._camera as THREE.PerspectiveCamera | THREE.OrthographicCamera;
+    context.camera = this._camera;
+  };
+
+  public change2DView = () => {
+    const context = Context.getInstance();
+    if (this._camera instanceof THREE.OrthographicCamera) {
+      console.log("orth");
+      new JEASINGS.JEasing(this._camera.position)
+        .to(
+          {
+            x: this._originalCamera!.position.x,
+            y: this._originalCamera!.position.y,
+            z: this._originalCamera!.position.z,
+          },
+          1.5,
+        )
+        .easing(JEASINGS.Quadratic.Out)
+        .onComplete(() => {
+          this._camera = this._perspectiveCamera;
+          context.updateControls(this._perspectiveCamera);
+          this._is2DView = false;
+        })
+        .start();
+
+      this._is2DView = false;
+    } else if (this._camera instanceof THREE.PerspectiveCamera) {
+      console.log("pers");
+      new JEASINGS.JEasing(this._camera.position)
+        .to({ x: 0, y: 0, z: 10 }, 1.5)
+        .easing(JEASINGS.Quadratic.Out)
+        .onComplete(() => {
+          console.log("완");
+          this._camera = this._orthographicCamera;
+          context.updateControls(this._orthographicCamera);
+          this._is2DView = true;
+        })
+        .start();
+    }
+  };
+
+  public dispose = () => {
+    this.clear();
+    this._sceneHelper.clear();
+  };
+
+  public subscribe(listener: () => void) {
+    this._listener = [...this._listener, listener];
+    this.notify();
+  }
+
+  public unsubscribe(listener: () => void) {
+    this._listener = this._listener.filter((l) => l !== listener);
+  }
+
+  public notify() {
+    this._listener.forEach((l) => l());
+  }
+
+  public render = () => {
+    this._helpers.forEach((helper) => {
+      helper.update();
+    });
+
+    if (this._selectCamera) {
+      JEASINGS.update();
+    }
+
+    // if (this._camera instanceof THREE.PerspectiveCamera) {
+    //   this.syncCamera(this._camera, this._orthographicCamera);
+    // } else {
+    //   this.syncCamera(this._camera, this._perspectiveCamera);
+    // }
+  };
+}

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -1,0 +1,176 @@
+import * as THREE from "three";
+import { SelectionBox } from "three/addons/interactive/SelectionBox.js";
+import { SelectionHelper } from "three/addons/interactive/SelectionHelper.js";
+import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
+import { OutlinePass } from "three/addons/postprocessing/OutlinePass.js";
+import { CopyShader } from "three/addons/shaders/CopyShader.js";
+import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
+import { FXAAShader } from "three/addons/shaders/FXAAShader.js";
+import { MOUSE_LEFT } from "../constants/controls";
+import { ShaderPass } from "three/examples/jsm/postprocessing/ShaderPass.js";
+
+const params = {
+  edgeStrength: 3.0,
+  edgeGlow: 0.0,
+  edgeThickness: 1.0,
+  pulsePeriod: 0,
+  rotate: false,
+  usePatternTexture: false,
+};
+
+export class Selector {
+  private box: SelectionBox;
+  private helper: SelectionHelper;
+  private _renderer: THREE.WebGLRenderer;
+  private _dom: HTMLElement;
+  private _scene: THREE.Scene;
+  private _camera: THREE.Camera;
+  // private _composer: EffectComposer;
+  // private _renderPass: RenderPass;
+  // private _outlinePass: OutlinePass;
+  // private _active_mouse_left: boolean = false;
+
+  private _pointerDown: (event: MouseEvent) => void;
+  private _pointerMove: (event: MouseEvent) => void;
+  private _pointerUp: (event: MouseEvent) => void;
+
+  constructor(
+    renderer: THREE.WebGLRenderer,
+    camera: THREE.Camera,
+    scene: THREE.Scene,
+    dom: HTMLElement
+  ) {
+    this._renderer = renderer;
+    this._dom = dom;
+    this._scene = scene;
+    this._camera = camera;
+    this.box = new SelectionBox(camera, scene);
+    this.helper = new SelectionHelper(renderer, "selectBox");
+
+    this._pointerDown = this.onPointerDown.bind(this);
+    this._pointerMove = this.onPointerMove.bind(this);
+    this._pointerUp = this.onPointerUp.bind(this);
+
+    const renderTarget = new THREE.WebGLRenderTarget(
+      this._dom.clientWidth,
+      this._dom.clientHeight
+    );
+
+    // this._composer = new EffectComposer(this._renderer, renderTarget);
+    // this._composer.renderer.autoClear = false;
+    // this._renderPass = new RenderPass(this._scene, this._camera);
+    // this._composer.addPass(this._renderPass);
+
+    // this._outlinePass = new OutlinePass(
+    //   new THREE.Vector2(
+    //     this._renderer.domElement.clientWidth,
+    //     this._renderer.domElement.clientHeight
+    //   ),
+    //   this._scene as THREE.Scene,
+    //   this._camera as THREE.Camera
+    // );
+    // this._outlinePass.edgeStrength = 3.0;
+    // this._outlinePass.edgeGlow = 0.1;
+    // this._outlinePass.edgeThickness = 1.0;
+    // this._outlinePass.visibleEdgeColor.set(0x00ced6);
+    // this._composer.addPass(this._outlinePass);
+
+    // const outputPas = new OutputPass();
+    // this._composer.addPass(outputPas);
+
+    // const effectFXAA = new ShaderPass(FXAAShader);
+
+    // effectFXAA.renderToScreen = true;
+
+    // effectFXAA.uniforms["resolution"].value.set(
+    //   1 / this._dom.clientWidth,
+    //   1 / this._dom.clientHeight
+    // );
+
+    // this._composer.addPass(effectFXAA);
+    // this._composer.setSize(this._dom.clientWidth, this._dom.clientHeight);
+
+    // const smaaPass = new SMAAPass(
+    //   this._renderer.domElement.clientWidth,
+    //   this._renderer.domElement.clientHeight
+    // );
+    // this._composer.addPass(smaaPass);
+    this._dom.addEventListener("pointerdown", (event: MouseEvent) => {
+      this._pointerDown(event);
+    });
+  }
+
+  // get composer() {
+  // return this._composer;
+  // }
+  // get renderPass() {
+  // return this._renderPass;
+  // }
+
+  public onPointerDown(event: MouseEvent) {
+    if (event.button === MOUSE_LEFT) {
+      // this._active_mouse_left = true;
+      // this._outlinePass.selectedObjects = [];
+
+      const rect = this._renderer.domElement.getBoundingClientRect();
+      this.box.startPoint.set(
+        (event.clientX / rect.width) * 2 - 1,
+        -(event.clientY / rect.height) * 2 + 1,
+        0
+      );
+
+      this._renderer.domElement.addEventListener(
+        "pointermove",
+        this._pointerMove
+      );
+
+      this._renderer.domElement.addEventListener("pointerup", this._pointerUp);
+    }
+  }
+
+  public onPointerMove(event: MouseEvent) {
+    // console.log(event.button);
+    if (this.helper.isDown) {
+      //   console.log("fasdfad");
+      const rect = this._renderer.domElement.getBoundingClientRect();
+      this.box.endPoint.set(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        -((event.clientY - rect.top) / rect.height) * 2 + 1,
+        0
+      );
+
+      // this._outlinePass.selectedObjects = this.box.select();
+      //   console.log(this._outlinePass.selectedObjects);
+      // this.render();
+    }
+  }
+
+  public onPointerUp(event: MouseEvent) {
+    event.stopPropagation();
+    const rect = this._renderer.domElement.getBoundingClientRect();
+
+    this.box.endPoint.set(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1,
+      0
+    );
+    // this._outlinePass.selectedObjects = this.box.select();
+
+    this._dom.removeEventListener("pointermove", this._pointerMove.bind(this));
+    this._dom.removeEventListener("pointerup", this._pointerUp);
+    this._dom.removeEventListener("pointerdown", this._pointerDown);
+  }
+
+  public dispose() {
+    this.helper.dispose();
+    this._dom.removeEventListener("pointermove", this._pointerMove);
+    this._dom.removeEventListener("pointerup", this._pointerUp);
+    this._dom.removeEventListener("pointerdown", this._pointerDown);
+  }
+
+  // public render() {
+  //   this._composer.render();
+  //   this._composer.renderer.autoClear = true;
+  // }
+}

--- a/src/core/transform-controls.ts
+++ b/src/core/transform-controls.ts
@@ -1,0 +1,1954 @@
+import * as THREE from "three";
+import { ControlsEvent } from "./perspective-controls";
+import { Context } from "./context";
+import { RGB_COLOR } from "../constants/color";
+import { Group } from "./group";
+
+const _raycaster = new THREE.Raycaster();
+
+const _tempVector = new THREE.Vector3();
+const _tempVector2 = new THREE.Vector3();
+const _tempQuaternion = new THREE.Quaternion();
+const _unit = {
+  X: new THREE.Vector3(1, 0, 0),
+  Y: new THREE.Vector3(0, 1, 0),
+  Z: new THREE.Vector3(0, 0, 1),
+};
+
+/**
+ * Fires if any type of change (object or property change) is performed. Property changes
+ * are separate events you can add event listeners to. The event type is "propertyname-changed".
+ *
+ * @event TransformControls#change
+ * @type {Object}
+ */
+const _changeEvent = { type: "change" };
+
+/**
+ * Fires if a pointer (mouse/touch) becomes active.
+ *
+ * @event TransformControls#mouseDown
+ * @type {Object}
+ */
+const _mouseDownEvent = { type: "mouseDown", mode: null };
+
+/**
+ * Fires if a pointer (mouse/touch) is no longer active.
+ *
+ * @event TransformControls#mouseUp
+ * @type {Object}
+ */
+const _mouseUpEvent = { type: "mouseUp", mode: null };
+
+/**
+ * Fires if the controlled 3D object is changed.
+ *
+ * @event TransformControls#objectChange
+ * @type {Object}
+ */
+const _objectChangeEvent = { type: "objectChange" };
+
+/**
+ * This class can be used to transform objects in 3D space by adapting a similar interaction model
+ * of DCC tools like Blender. Unlike other controls, it is not intended to transform the scene's camera.
+ *
+ * `TransformControls` expects that its attached 3D object is part of the scene graph.
+ *
+ * @augments THREE.Controls
+ */
+
+const _m1 = /*@__PURE__*/ new THREE.Matrix4();
+function _attach(parent: THREE.Object3D, child: THREE.Object3D) {
+  // adds object as a child of this, while maintaining the object's world transform
+
+  // Note: This method does not support scene graphs having non-uniformly-scaled nodes(s)
+
+  parent.updateWorldMatrix(true, false);
+
+  _m1.copy(parent.matrixWorld).invert();
+
+  if (child.parent !== null) {
+    child.parent.updateWorldMatrix(true, false);
+
+    _m1.multiply(child.parent.matrixWorld);
+  }
+
+  child.applyMatrix4(_m1);
+
+  child.removeFromParent();
+  child.parent = parent;
+  parent.children.push(child);
+
+  child.updateWorldMatrix(false, true);
+
+  child.dispatchEvent({ type: "added" });
+  parent.dispatchEvent({ type: "childadded", child });
+
+  return parent;
+}
+
+type defaultValueType = {
+  camera: THREE.Camera | undefined;
+  object: THREE.Object3D | undefined;
+  enabled: boolean;
+  axis: string | null;
+  mode: string;
+  translationSnap: number | null;
+  rotationSnap: number | null;
+  scaleSnap: number | null;
+  space: string;
+  size: number;
+  dragging: boolean;
+  showX: boolean;
+  showY: boolean;
+  showZ: boolean;
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  minZ: number;
+  maxZ: number;
+  worldPosition: THREE.Vector3;
+  worldPositionStart: THREE.Vector3;
+  worldQuaternion: THREE.Quaternion;
+  worldQuaternionStart: THREE.Quaternion;
+  cameraPosition: THREE.Vector3;
+  cameraQuaternion: THREE.Quaternion;
+  pointStart: THREE.Vector3;
+  pointEnd: THREE.Vector3;
+  rotationAxis: THREE.Vector3;
+  rotationAngle: number;
+  eye: THREE.Vector3;
+};
+class TransformControls extends THREE.Controls<ControlsEvent> {
+  /**
+   * Constructs a new controls instance.
+   *
+   * @param {Camera} camera - The camera of the rendered scene.
+   * @param {?HTMLDOMElement} domElement - The HTML element used for event listeners.
+   */
+  private _root: TransformControlsRoot;
+  private _gizmo: TransformControlsGizmo;
+  private _plane: TransformControlsPlane;
+  private _offset: THREE.Vector3;
+  private _startNorm: THREE.Vector3;
+  private _endNorm: THREE.Vector3;
+  private _cameraScale: THREE.Vector3;
+  private _parentPosition: THREE.Vector3;
+  private _parentQuaternion: THREE.Quaternion;
+  private _parentQuaternionInv: THREE.Quaternion;
+  private _parentScale: THREE.Vector3;
+  private _worldScaleStart: THREE.Vector3;
+  private _worldQuaternionInv: THREE.Quaternion;
+  private _worldScale: THREE.Vector3;
+  private _positionStart: THREE.Vector3;
+  private _quaternionStart: THREE.Quaternion;
+  private _scaleStart: THREE.Vector3;
+
+  private _originalParents = new Map<
+    THREE.Object3D,
+    {
+      parent: THREE.Object3D;
+      index: number;
+      worldPosition: THREE.Vector3;
+      worldQuaternion: THREE.Quaternion;
+      worldScale: THREE.Vector3;
+    }
+  >();
+  private _getPointer: (event: THREE.Event) => THREE.Vector2 & { button: number };
+  private _onPointerDown: (event: THREE.Event) => void;
+  private _onPointerHover: (event: THREE.Event) => void;
+  private _onPointerMove: (event: THREE.Event) => void;
+  private _onPointerUp: (event: THREE.Event) => void;
+  public _group: THREE.Group | null;
+  constructor(camera: THREE.Camera, domElement: HTMLDivElement) {
+    super(camera, domElement);
+
+    const root = new TransformControlsRoot(this);
+    this._root = root;
+
+    const gizmo = new TransformControlsGizmo();
+    this._gizmo = gizmo;
+    root.add(gizmo);
+
+    const plane = new TransformControlsPlane();
+    this._plane = plane;
+    root.add(plane);
+
+    this._group = new Group();
+    // this._boxHelper = new THREE.BoxHelper(this._group, 0x00ff00);
+
+    const scope = this;
+
+    // Defined getter, setter and store for a property
+
+    function defineProperty(
+      propName: keyof defaultValueType,
+      defaultValue: defaultValueType[keyof defaultValueType],
+    ) {
+      let propValue = defaultValue;
+
+      Object.defineProperty(scope, propName, {
+        get: function () {
+          return propValue !== undefined ? propValue : defaultValue;
+        },
+
+        set: function (value) {
+          if (propValue !== value) {
+            propValue = value;
+            plane[propName] = value;
+            gizmo[propName] = value;
+
+            scope.dispatchEvent({ type: propName + "-changed", value: value });
+            scope.dispatchEvent(_changeEvent);
+          }
+        },
+      });
+
+      scope[propName] = defaultValue;
+      plane[propName] = defaultValue;
+      gizmo[propName] = defaultValue;
+    }
+
+    // Define properties with getters/setter
+    // Setting the defined property will automatically trigger change event
+    // Defined properties are passed down to gizmo and plane
+
+    /**
+     * The camera of the rendered scene.
+     *
+     * @name TransformControls#camera
+     * @type {Camera}
+     */
+    defineProperty("camera", camera);
+    defineProperty("object", undefined);
+    defineProperty("enabled", true);
+
+    /**
+     * The current transformation axis.
+     *
+     * @name TransformControls#axis
+     * @type {string}
+     */
+    defineProperty("axis", null);
+
+    /**
+     * The current transformation axis.
+     *
+     * @name TransformControls#mode
+     * @type {('translate'|'rotate'|'scale')}
+     * @default 'translate'
+     */
+    defineProperty("mode", "translate");
+
+    /**
+     * By default, 3D objects are continuously translated. If you set this property to a numeric
+     * value (world units), you can define in which steps the 3D object should be translated.
+     *
+     * @name TransformControls#translationSnap
+     * @type {?number}
+     * @default null
+     */
+    defineProperty("translationSnap", null);
+
+    /**
+     * By default, 3D objects are continuously rotated. If you set this property to a numeric
+     * value (radians), you can define in which steps the 3D object should be rotated.
+     *
+     * @name TransformControls#rotationSnap
+     * @type {?number}
+     * @default null
+     */
+    defineProperty("rotationSnap", null);
+
+    /**
+     * By default, 3D objects are continuously scaled. If you set this property to a numeric
+     * value, you can define in which steps the 3D object should be scaled.
+     *
+     * @name TransformControls#scaleSnap
+     * @type {?number}
+     * @default null
+     */
+    defineProperty("scaleSnap", null);
+
+    /**
+     * Defines in which coordinate space transformations should be performed.
+     *
+     * @name TransformControls#space
+     * @type {('world'|'local')}
+     * @default 'world'
+     */
+    defineProperty("space", "world");
+
+    /**
+     * The size of the helper UI (axes/planes).
+     *
+     * @name TransformControls#size
+     * @type {number}
+     * @default 1
+     */
+    defineProperty("size", 1);
+
+    /**
+     * Whether dragging is currently performed or not.
+     *
+     * @name TransformControls#dragging
+     * @type {boolean}
+     * @readonly
+     * @default false
+     */
+    defineProperty("dragging", false);
+
+    /**
+     * Whether the x-axis helper should be visible or not.
+     *
+     * @name TransformControls#showX
+     * @type {boolean}
+     * @default true
+     */
+    defineProperty("showX", true);
+
+    /**
+     * Whether the y-axis helper should be visible or not.
+     *
+     * @name TransformControls#showY
+     * @type {boolean}
+     * @default true
+     */
+    defineProperty("showY", true);
+
+    /**
+     * Whether the z-axis helper should be visible or not.
+     *
+     * @name TransformControls#showZ
+     * @type {boolean}
+     * @default true
+     */
+    defineProperty("showZ", true);
+
+    /**
+     * The minimum allowed X position during translation.
+     *
+     * @name TransformControls#minX
+     * @type {number}
+     * @default -Infinity
+     */
+    defineProperty("minX", -Infinity);
+
+    /**
+     * The maximum allowed X position during translation.
+     *
+     * @name TransformControls#maxX
+     * @type {number}
+     * @default Infinity
+     */
+    defineProperty("maxX", Infinity);
+
+    /**
+     * The minimum allowed y position during translation.
+     *
+     * @name TransformControls#minY
+     * @type {number}
+     * @default -Infinity
+     */
+    defineProperty("minY", -Infinity);
+
+    /**
+     * The maximum allowed Y position during translation.
+     *
+     * @name TransformControls#maxY
+     * @type {number}
+     * @default Infinity
+     */
+    defineProperty("maxY", Infinity);
+
+    /**
+     * The minimum allowed z position during translation.
+     *
+     * @name TransformControls#minZ
+     * @type {number}
+     * @default -Infinity
+     */
+    defineProperty("minZ", -Infinity);
+
+    /**
+     * The maximum allowed Z position during translation.
+     *
+     * @name TransformControls#maxZ
+     * @type {number}
+     * @default Infinity
+     */
+    defineProperty("maxZ", Infinity);
+
+    // Reusable utility variables
+
+    const worldPosition = new THREE.Vector3();
+    const worldPositionStart = new THREE.Vector3();
+    const worldQuaternion = new THREE.Quaternion();
+    const worldQuaternionStart = new THREE.Quaternion();
+    const cameraPosition = new THREE.Vector3();
+    const cameraQuaternion = new THREE.Quaternion();
+    const pointStart = new THREE.Vector3();
+    const pointEnd = new THREE.Vector3();
+    const rotationAxis = new THREE.Vector3();
+    const rotationAngle = 0;
+    const eye = new THREE.Vector3();
+
+    // TODO: remove properties unused in plane and gizmo
+
+    defineProperty("worldPosition", worldPosition);
+    defineProperty("worldPositionStart", worldPositionStart);
+    defineProperty("worldQuaternion", worldQuaternion);
+    defineProperty("worldQuaternionStart", worldQuaternionStart);
+    defineProperty("cameraPosition", cameraPosition);
+    defineProperty("cameraQuaternion", cameraQuaternion);
+    defineProperty("pointStart", pointStart);
+    defineProperty("pointEnd", pointEnd);
+    defineProperty("rotationAxis", rotationAxis);
+    defineProperty("rotationAngle", rotationAngle);
+    defineProperty("eye", eye);
+
+    this._offset = new THREE.Vector3();
+    this._startNorm = new THREE.Vector3();
+    this._endNorm = new THREE.Vector3();
+    this._cameraScale = new THREE.Vector3();
+
+    this._parentPosition = new THREE.Vector3();
+    this._parentQuaternion = new THREE.Quaternion();
+    this._parentQuaternionInv = new THREE.Quaternion();
+    this._parentScale = new THREE.Vector3();
+
+    this._worldScaleStart = new THREE.Vector3();
+    this._worldQuaternionInv = new THREE.Quaternion();
+    this._worldScale = new THREE.Vector3();
+
+    this._positionStart = new THREE.Vector3();
+    this._quaternionStart = new THREE.Quaternion();
+    this._scaleStart = new THREE.Vector3();
+
+    this._getPointer = getPointer.bind(this);
+    this._onPointerDown = onPointerDown.bind(this);
+    this._onPointerHover = onPointerHover.bind(this);
+    this._onPointerMove = onPointerMove.bind(this);
+    this._onPointerUp = onPointerUp.bind(this);
+
+    if (domElement !== null) {
+      this.connect();
+    }
+  }
+
+  get camera() {
+    return this.camera;
+  }
+
+  set camera(camera: THREE.Camera) {
+    this.camera = camera;
+  }
+  connect(): void {
+    super.connect(this.domElement!);
+
+    this.domElement!.addEventListener("pointerdown", this._onPointerDown);
+    this.domElement!.addEventListener("pointermove", this._onPointerHover);
+    this.domElement!.addEventListener("pointerup", this._onPointerUp);
+
+    this.domElement!.style.touchAction = "none"; // disable touch scroll
+  }
+
+  disconnect(): void {
+    this.domElement!.removeEventListener("pointerdown", this._onPointerDown);
+    this.domElement!.removeEventListener("pointermove", this._onPointerHover);
+    this.domElement!.removeEventListener("pointermove", this._onPointerMove);
+    this.domElement!.removeEventListener("pointerup", this._onPointerUp);
+
+    this.domElement!.style.touchAction = "auto";
+  }
+
+  /**
+   * Returns the visual representation of the controls. Add the helper to your scene to
+   * visually transform the attached  3D object.
+   *
+   * @return {TransformControlsRoot} The helper.
+   */
+  getHelper() {
+    return this._root;
+  }
+
+  get group() {
+    return this._group;
+  }
+
+  pointerHover(pointer: THREE.Vector2): void {
+    if (this.object === undefined || this.dragging === true) return;
+
+    if (pointer !== null) _raycaster.setFromCamera(pointer, this.camera);
+
+    const intersect = intersectObjectWithRay(this._gizmo.picker[this.mode], _raycaster);
+
+    if (intersect) {
+      this.axis = intersect.object.name;
+    } else {
+      this.axis = null;
+    }
+  }
+
+  pointerDown(pointer) {
+    if (
+      this.object === undefined ||
+      this.dragging === true ||
+      (pointer != null && pointer.button !== 0)
+    )
+      return;
+
+    if (this.axis !== null) {
+      if (pointer !== null) _raycaster.setFromCamera(pointer, this.camera);
+
+      const planeIntersect = intersectObjectWithRay(this._plane, _raycaster, true);
+
+      if (planeIntersect) {
+        this.object.updateMatrixWorld();
+        this.object.parent.updateMatrixWorld();
+
+        this._positionStart.copy(this.object.position);
+        this._quaternionStart.copy(this.object.quaternion);
+        this._scaleStart.copy(this.object.scale);
+
+        this.object.matrixWorld.decompose(
+          this.worldPositionStart,
+          this.worldQuaternionStart,
+          this._worldScaleStart,
+        );
+
+        this.pointStart.copy(planeIntersect.point).sub(this.worldPositionStart);
+      }
+
+      this.dragging = true;
+      _mouseDownEvent.mode = this.mode;
+      this.dispatchEvent(_mouseDownEvent);
+    }
+  }
+
+  pointerMove(pointer) {
+    const axis = this.axis;
+    const mode = this.mode;
+    const object = this.object;
+    let space = this.space;
+
+    if (mode === "scale") {
+      space = "local";
+    } else if (axis === "E" || axis === "XYZE" || axis === "XYZ") {
+      space = "world";
+    }
+
+    if (
+      object === undefined ||
+      axis === null ||
+      this.dragging === false ||
+      (pointer !== null && pointer.button !== -1)
+    )
+      return;
+
+    if (pointer !== null) _raycaster.setFromCamera(pointer, this.camera);
+
+    const planeIntersect = intersectObjectWithRay(this._plane, _raycaster, true);
+
+    if (!planeIntersect) return;
+
+    this.pointEnd.copy(planeIntersect.point).sub(this.worldPositionStart);
+
+    if (mode === "translate") {
+      // Apply translate
+
+      this._offset.copy(this.pointEnd).sub(this.pointStart);
+
+      if (space === "local" && axis !== "XYZ") {
+        this._offset.applyQuaternion(this._worldQuaternionInv);
+      }
+
+      if (axis.indexOf("X") === -1) this._offset.x = 0;
+      if (axis.indexOf("Y") === -1) this._offset.y = 0;
+      if (axis.indexOf("Z") === -1) this._offset.z = 0;
+
+      if (space === "local" && axis !== "XYZ") {
+        this._offset.applyQuaternion(this._quaternionStart).divide(this._parentScale);
+      } else {
+        this._offset.applyQuaternion(this._parentQuaternionInv).divide(this._parentScale);
+      }
+
+      object.position.copy(this._offset).add(this._positionStart);
+
+      // Apply translation snap
+
+      if (this.translationSnap) {
+        if (space === "local") {
+          object.position.applyQuaternion(_tempQuaternion.copy(this._quaternionStart).invert());
+
+          if (axis.search("X") !== -1) {
+            object.position.x =
+              Math.round(object.position.x / this.translationSnap) * this.translationSnap;
+          }
+
+          if (axis.search("Y") !== -1) {
+            object.position.y =
+              Math.round(object.position.y / this.translationSnap) * this.translationSnap;
+          }
+
+          if (axis.search("Z") !== -1) {
+            object.position.z =
+              Math.round(object.position.z / this.translationSnap) * this.translationSnap;
+          }
+
+          object.position.applyQuaternion(this._quaternionStart);
+        }
+
+        if (space === "world") {
+          if (object.parent) {
+            object.position.add(_tempVector.setFromMatrixPosition(object.parent.matrixWorld));
+          }
+
+          if (axis.search("X") !== -1) {
+            object.position.x =
+              Math.round(object.position.x / this.translationSnap) * this.translationSnap;
+          }
+
+          if (axis.search("Y") !== -1) {
+            object.position.y =
+              Math.round(object.position.y / this.translationSnap) * this.translationSnap;
+          }
+
+          if (axis.search("Z") !== -1) {
+            object.position.z =
+              Math.round(object.position.z / this.translationSnap) * this.translationSnap;
+          }
+
+          if (object.parent) {
+            object.position.sub(_tempVector.setFromMatrixPosition(object.parent.matrixWorld));
+          }
+        }
+      }
+
+      object.position.x = Math.max(this.minX, Math.min(this.maxX, object.position.x));
+      object.position.y = Math.max(this.minY, Math.min(this.maxY, object.position.y));
+      object.position.z = Math.max(this.minZ, Math.min(this.maxZ, object.position.z));
+    } else if (mode === "scale") {
+      if (axis.search("XYZ") !== -1) {
+        let d = this.pointEnd.length() / this.pointStart.length();
+        if (this.pointEnd.dot(this.pointStart) < 0) d *= -1;
+        _tempVector2.set(d, d, d);
+      } else {
+        _tempVector.copy(this.pointStart);
+        _tempVector2.copy(this.pointEnd);
+
+        _tempVector.applyQuaternion(this._worldQuaternionInv);
+        _tempVector2.applyQuaternion(this._worldQuaternionInv);
+
+        _tempVector2.divide(_tempVector);
+
+        if (axis.search("X") === -1) {
+          _tempVector2.x = 1;
+        }
+
+        if (axis.search("Y") === -1) {
+          _tempVector2.y = 1;
+        }
+
+        if (axis.search("Z") === -1) {
+          _tempVector2.z = 1;
+        }
+      }
+
+      // 스케일 적용 시 초기 스케일 값으로 리셋
+      object.scale.copy(this._scaleStart).multiply(_tempVector2);
+
+      if (this.scaleSnap) {
+        if (axis.search("X") !== -1) {
+          object.scale.x = Math.round(object.scale.x / this.scaleSnap) * this.scaleSnap;
+        }
+
+        if (axis.search("Y") !== -1) {
+          object.scale.y = Math.round(object.scale.y / this.scaleSnap) * this.scaleSnap;
+        }
+
+        if (axis.search("Z") !== -1) {
+          object.scale.z = Math.round(object.scale.z / this.scaleSnap) * this.scaleSnap;
+        }
+      }
+    } else if (mode === "rotate") {
+      this._offset.copy(this.pointEnd).sub(this.pointStart);
+
+      const ROTATION_SPEED =
+        20 /
+        this.worldPosition.distanceTo(_tempVector.setFromMatrixPosition(this.camera.matrixWorld));
+
+      let _inPlaneRotation = false;
+
+      if (axis === "XYZE") {
+        this.rotationAxis.copy(this._offset).cross(this.eye).normalize();
+        this.rotationAngle =
+          this._offset.dot(_tempVector.copy(this.rotationAxis).cross(this.eye)) * ROTATION_SPEED;
+      } else if (axis === "X" || axis === "Y" || axis === "Z") {
+        this.rotationAxis.copy(_unit[axis]);
+
+        _tempVector.copy(_unit[axis]);
+
+        if (space === "local") {
+          _tempVector.applyQuaternion(this.worldQuaternion);
+        }
+
+        _tempVector.cross(this.eye);
+
+        // When _tempVector is 0 after cross with this.eye the vectors are parallel and should use in-plane rotation logic.
+        if (_tempVector.length() === 0) {
+          _inPlaneRotation = true;
+        } else {
+          this.rotationAngle = this._offset.dot(_tempVector.normalize()) * ROTATION_SPEED;
+        }
+      }
+
+      if (axis === "E" || _inPlaneRotation) {
+        this.rotationAxis.copy(this.eye);
+        this.rotationAngle = this.pointEnd.angleTo(this.pointStart);
+
+        this._startNorm.copy(this.pointStart).normalize();
+        this._endNorm.copy(this.pointEnd).normalize();
+
+        this.rotationAngle *= this._endNorm.cross(this._startNorm).dot(this.eye) < 0 ? 1 : -1;
+      }
+
+      // Apply rotation snap
+
+      if (this.rotationSnap)
+        this.rotationAngle = Math.round(this.rotationAngle / this.rotationSnap) * this.rotationSnap;
+
+      // Apply rotate
+      if (space === "local" && axis !== "E" && axis !== "XYZE") {
+        object.quaternion.copy(this._quaternionStart);
+        object.quaternion
+          .multiply(_tempQuaternion.setFromAxisAngle(this.rotationAxis, this.rotationAngle))
+          .normalize();
+      } else {
+        this.rotationAxis.applyQuaternion(this._parentQuaternionInv);
+        object.quaternion.copy(
+          _tempQuaternion.setFromAxisAngle(this.rotationAxis, this.rotationAngle),
+        );
+        object.quaternion.multiply(this._quaternionStart).normalize();
+      }
+    }
+
+    this.dispatchEvent(_changeEvent);
+    this.dispatchEvent(_objectChangeEvent);
+  }
+
+  pointerUp(pointer) {
+    if (pointer !== null && pointer.button !== 0) return;
+
+    if (this.dragging && this.axis !== null) {
+      _mouseUpEvent.mode = this.mode;
+      this.dispatchEvent(_mouseUpEvent);
+    }
+
+    this.dragging = false;
+    this.axis = null;
+  }
+
+  dispose() {
+    this.disconnect();
+
+    this._root.dispose();
+  }
+
+  attach(objects: THREE.Object3D[]): TransformControls {
+    const scene = Context.getInstance().scene;
+
+    // 새 그룹 생성
+    this._group = new THREE.Group();
+
+    // 경계 상자 계산
+    const minPos = new THREE.Vector3(Infinity, Infinity, Infinity);
+    const maxPos = new THREE.Vector3(-Infinity, -Infinity, -Infinity);
+
+    // 원본 상태 저장 및 경계 계산
+    objects.forEach((object) => {
+      if (object.parent) {
+        // 현재 월드 상태 저장
+        const worldPosition = new THREE.Vector3();
+        const worldQuaternion = new THREE.Quaternion();
+        const worldScale = new THREE.Vector3();
+
+        object.updateMatrixWorld(true); // 매트릭스 강제 업데이트
+        object.getWorldPosition(worldPosition);
+        object.getWorldQuaternion(worldQuaternion);
+        object.getWorldScale(worldScale);
+
+        this._originalParents.set(object, {
+          parent: object.parent,
+          index: object.parent.children.indexOf(object),
+          worldPosition: worldPosition.clone(),
+          worldQuaternion: worldQuaternion.clone(),
+          worldScale: worldScale.clone(),
+        });
+      }
+
+      const worldPosition = new THREE.Vector3();
+      object.getWorldPosition(worldPosition);
+      minPos.min(worldPosition);
+      maxPos.max(worldPosition);
+    });
+
+    // 그룹 위치 설정
+    const center = new THREE.Vector3();
+    center.addVectors(minPos, maxPos).multiplyScalar(0.5);
+    this._group.position.copy(center);
+
+    // 먼저 씬에 그룹 추가
+    scene.add(this._group);
+
+    // 그룹에 객체 추가
+    objects.forEach((object) => {
+      _attach(this._group!, object);
+      object.matrixAutoUpdate = false;
+
+      // this._group.attach(object);
+    });
+
+    this.object = this._group;
+    this._root.visible = true;
+
+    return this;
+  }
+
+  detach(): TransformControls {
+    if (!this._group || !this.object) {
+      return this;
+    }
+
+    const children = [...this._group.children];
+
+    children.forEach((child) => {
+      const originalData = this._originalParents.get(child);
+      if (originalData) {
+        const { parent } = originalData;
+        _attach(parent, child);
+        child.matrixAutoUpdate = false;
+
+        const { index } = originalData;
+        const currentIndex = parent.children.indexOf(child);
+        if (index !== currentIndex && index < parent.children.length) {
+          console.log(child.rotation.x, child.rotation.y, child.rotation.z);
+          console.log(child.scale.x, child.scale.y, child.scale.z);
+          parent.children.splice(currentIndex, 1);
+          parent.children.splice(index, 0, child);
+        }
+      }
+    });
+
+    // 그룹 정리
+    if (this._group.parent) {
+      this._group.parent.remove(this._group);
+    }
+
+    // 상태 초기화
+    this._group = null;
+    this.object = undefined;
+    this.axis = null;
+    this._root.visible = false;
+    this._originalParents.clear();
+
+    return this;
+  }
+  /**
+   * Resets the object's position, rotation and scale to when the current transform began.
+   */
+  reset() {
+    if (!this.enabled) return;
+
+    if (this.dragging) {
+      this.object.position.copy(this._positionStart);
+      this.object.quaternion.copy(this._quaternionStart);
+      this.object.scale.copy(this._scaleStart);
+
+      this.dispatchEvent(_changeEvent);
+      this.dispatchEvent(_objectChangeEvent);
+
+      this.pointStart.copy(this.pointEnd);
+    }
+  }
+
+  /**
+   * Returns the raycaster that is used for user interaction. This object is shared between all
+   * instances of `TransformControls`.
+   *
+   * @returns {THREE.Raycaster} The internal raycaster.
+   */
+  getRaycaster() {
+    return _raycaster;
+  }
+
+  /**
+   * Returns the transformation mode.
+   *
+   * @returns {'translate'|'rotate'|'scale'} The transformation mode.
+   */
+  getMode() {
+    return this.mode;
+  }
+
+  /**
+   * Sets the given transformation mode.
+   *
+   * @param {'translate'|'rotate'|'scale'} mode - The transformation mode to set.
+   */
+  setMode(mode) {
+    this.mode = mode;
+  }
+
+  /**
+   * Sets the translation snap.
+   *
+   * @param {?number} translationSnap - The translation snap to set.
+   */
+  setTranslationSnap(translationSnap) {
+    this.translationSnap = translationSnap;
+  }
+
+  /**
+   * Sets the rotation snap.
+   *
+   * @param {?number} rotationSnap - The rotation snap to set.
+   */
+  setRotationSnap(rotationSnap) {
+    this.rotationSnap = rotationSnap;
+  }
+
+  /**
+   * Sets the scale snap.
+   *
+   * @param {?number} scaleSnap - The scale snap to set.
+   */
+  setScaleSnap(scaleSnap) {
+    this.scaleSnap = scaleSnap;
+  }
+
+  /**
+   * Sets the size of the helper UI.
+   *
+   * @param {number} size - The size to set.
+   */
+  setSize(size) {
+    this.size = size;
+  }
+
+  /**
+   * Sets the coordinate space in which transformations are applied.
+   *
+   * @param {'world'|'local'} space - The space to set.
+   */
+  setSpace(space) {
+    this.space = space;
+  }
+}
+
+// mouse / touch event handlers
+
+function getPointer(event: THREE.Event): Object.assign<THREE.Vector2, { button: number }> {
+  if (this.domElement.ownerDocument.pointerLockElement) {
+    return {
+      x: 0,
+      y: 0,
+      button: event.button,
+    };
+  } else {
+    const rect = this.domElement.getBoundingClientRect();
+
+    return {
+      x: ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      y: (-(event.clientY - rect.top) / rect.height) * 2 + 1,
+      button: event.button,
+    };
+  }
+}
+
+function onPointerHover(event) {
+  if (!this.enabled) return;
+
+  switch (event.pointerType) {
+    case "mouse":
+    case "pen":
+      this.pointerHover(this._getPointer(event));
+      break;
+  }
+}
+
+function onPointerDown(event) {
+  if (!this.enabled) return;
+
+  if (!document.pointerLockElement) {
+    this.domElement.setPointerCapture(event.pointerId);
+  }
+
+  this.domElement.addEventListener("pointermove", this._onPointerMove);
+
+  this.pointerHover(this._getPointer(event));
+  this.pointerDown(this._getPointer(event));
+}
+
+function onPointerMove(event) {
+  if (!this.enabled) return;
+
+  this.pointerMove(this._getPointer(event));
+}
+
+function onPointerUp(event) {
+  if (!this.enabled) return;
+
+  this.domElement.releasePointerCapture(event.pointerId);
+
+  this.domElement.removeEventListener("pointermove", this._onPointerMove);
+
+  this.pointerUp(this._getPointer(event));
+}
+
+function intersectObjectWithRay(object, raycaster, includeInvisible) {
+  const allIntersections = raycaster.intersectObject(object, true);
+
+  for (let i = 0; i < allIntersections.length; i++) {
+    if (allIntersections[i].object.visible || includeInvisible) {
+      return allIntersections[i];
+    }
+  }
+
+  return false;
+}
+
+//
+
+// Reusable utility variables
+
+const _tempEuler = new THREE.Euler();
+const _alignVector = new THREE.Vector3(0, 1, 0);
+const _zeroVector = new THREE.Vector3(0, 0, 0);
+const _lookAtMatrix = new THREE.Matrix4();
+const _tempQuaternion2 = new THREE.Quaternion();
+const _identityQuaternion = new THREE.Quaternion();
+const _dirVector = new THREE.Vector3();
+const _tempMatrix = new THREE.Matrix4();
+
+const _unitX = new THREE.Vector3(1, 0, 0);
+const _unitY = new THREE.Vector3(0, 1, 0);
+const _unitZ = new THREE.Vector3(0, 0, 1);
+
+const _v1 = new THREE.Vector3();
+const _v2 = new THREE.Vector3();
+const _v3 = new THREE.Vector3();
+
+class TransformControlsRoot extends THREE.Object3D {
+  constructor(controls) {
+    super();
+
+    this.isTransformControlsRoot = true;
+
+    this.controls = controls;
+    this.visible = false;
+  }
+
+  // updateMatrixWorld updates key transformation variables
+  updateMatrixWorld(force) {
+    const controls = this.controls;
+
+    if (controls.object !== undefined) {
+      controls.object.updateMatrixWorld();
+
+      if (controls.object.parent === null) {
+        console.error(
+          "TransformControls: The attached 3D object must be a part of the scene graph.",
+        );
+      } else {
+        controls.object.parent.matrixWorld.decompose(
+          controls._parentPosition,
+          controls._parentQuaternion,
+          controls._parentScale,
+        );
+
+        controls.object.matrixWorld.decompose(
+          controls.worldPosition,
+          controls.worldQuaternion,
+          controls._worldScale,
+        );
+        // console.log(controls.object.name, controls.object.quaternion);
+        // controls.object.children.forEach((child) => {
+        //   console.log(child.name, child.position);
+        // });
+
+        controls._parentQuaternionInv.copy(controls._parentQuaternion).invert();
+        controls._worldQuaternionInv.copy(controls.worldQuaternion).invert();
+      }
+    }
+
+    controls.camera.updateMatrixWorld();
+    controls.camera.matrixWorld.decompose(
+      controls.cameraPosition,
+      controls.cameraQuaternion,
+      controls._cameraScale,
+    );
+
+    if (controls.camera.isOrthographicCamera) {
+      controls.camera.getWorldDirection(controls.eye).negate();
+    } else {
+      controls.eye.copy(controls.cameraPosition).sub(controls.worldPosition).normalize();
+    }
+
+    super.updateMatrixWorld(force);
+  }
+
+  dispose() {
+    this.traverse(function (child) {
+      if (child.geometry) child.geometry.dispose();
+      if (child.material) child.material.dispose();
+    });
+  }
+}
+
+class TransformControlsGizmo extends THREE.Object3D {
+  constructor() {
+    super();
+
+    this.isTransformControlsGizmo = true;
+
+    this.type = "TransformControlsGizmo";
+
+    // shared materials
+
+    const gizmoMaterial = new THREE.MeshBasicMaterial({
+      depthTest: false,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
+      transparent: true,
+    });
+
+    const gizmoLineMaterial = new THREE.LineBasicMaterial({
+      depthTest: false,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
+      transparent: true,
+    });
+
+    // Make unique material for each axis/color
+
+    const matInvisible = gizmoMaterial.clone();
+    matInvisible.opacity = 0.15;
+
+    const matHelper = gizmoLineMaterial.clone();
+    matHelper.opacity = 0.5;
+
+    const matRed = gizmoMaterial.clone();
+    matRed.color.setHex(RGB_COLOR.r);
+
+    const matGreen = gizmoMaterial.clone();
+    matGreen.color.setHex(RGB_COLOR.g);
+
+    const matBlue = gizmoMaterial.clone();
+    matBlue.color.setHex(RGB_COLOR.b);
+
+    const matRedTransparent = gizmoMaterial.clone();
+    matRedTransparent.color.setHex(RGB_COLOR.r);
+    matRedTransparent.opacity = 0.5;
+
+    const matGreenTransparent = gizmoMaterial.clone();
+    matGreenTransparent.color.setHex(RGB_COLOR.g);
+    matGreenTransparent.opacity = 0.5;
+
+    const matBlueTransparent = gizmoMaterial.clone();
+    matBlueTransparent.color.setHex(RGB_COLOR.b);
+    matBlueTransparent.opacity = 0.5;
+
+    const matWhiteTransparent = gizmoMaterial.clone();
+    matWhiteTransparent.opacity = 0.25;
+
+    const matYellowTransparent = gizmoMaterial.clone();
+    matYellowTransparent.color.setHex(0xffff00);
+    matYellowTransparent.opacity = 0.25;
+
+    const matYellow = gizmoMaterial.clone();
+    matYellow.color.setHex(0xffff00);
+
+    const matGray = gizmoMaterial.clone();
+    matGray.color.setHex(0x787878);
+
+    // reusable geometry
+
+    const arrowGeometry = new THREE.CylinderGeometry(0, 0.04, 0.1, 12);
+    arrowGeometry.translate(0, 0.05, 0);
+
+    const scaleHandleGeometry = new THREE.BoxGeometry(0.08, 0.08, 0.08);
+    scaleHandleGeometry.translate(0, 0.04, 0);
+
+    const lineGeometry = new THREE.BufferGeometry();
+    lineGeometry.setAttribute("position", new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0], 3));
+
+    const lineGeometry2 = new THREE.CylinderGeometry(0.0075, 0.0075, 0.5, 3);
+    lineGeometry2.translate(0, 0.25, 0);
+
+    function CircleGeometry(radius, arc) {
+      const geometry = new THREE.TorusGeometry(radius, 0.0075, 3, 64, arc * Math.PI * 2);
+      geometry.rotateY(Math.PI / 2);
+      geometry.rotateX(Math.PI / 2);
+      return geometry;
+    }
+
+    // Special geometry for transform helper. If scaled with position vector it spans from [0,0,0] to position
+
+    function TranslateHelperGeometry() {
+      const geometry = new THREE.BufferGeometry();
+
+      geometry.setAttribute("position", new THREE.Float32BufferAttribute([0, 0, 0, 1, 1, 1], 3));
+
+      return geometry;
+    }
+
+    // Gizmo definitions - custom hierarchy definitions for setupGizmo() function
+
+    const gizmoTranslate = {
+      X: [
+        [new THREE.Mesh(arrowGeometry, matRed), [0.5, 0, 0], [0, 0, -Math.PI / 2]],
+        [new THREE.Mesh(arrowGeometry, matRed), [-0.5, 0, 0], [0, 0, Math.PI / 2]],
+        [new THREE.Mesh(lineGeometry2, matRed), [0, 0, 0], [0, 0, -Math.PI / 2]],
+      ],
+      Y: [
+        [new THREE.Mesh(arrowGeometry, matGreen), [0, 0.5, 0]],
+        [new THREE.Mesh(arrowGeometry, matGreen), [0, -0.5, 0], [Math.PI, 0, 0]],
+        [new THREE.Mesh(lineGeometry2, matGreen)],
+      ],
+      Z: [
+        [new THREE.Mesh(arrowGeometry, matBlue), [0, 0, 0.5], [Math.PI / 2, 0, 0]],
+        [new THREE.Mesh(arrowGeometry, matBlue), [0, 0, -0.5], [-Math.PI / 2, 0, 0]],
+        [new THREE.Mesh(lineGeometry2, matBlue), null, [Math.PI / 2, 0, 0]],
+      ],
+      XYZ: [
+        [
+          new THREE.Mesh(new THREE.OctahedronGeometry(0.1, 0), matWhiteTransparent.clone()),
+          [0, 0, 0],
+        ],
+      ],
+      XY: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 0.01), matBlueTransparent.clone()),
+          [0.15, 0.15, 0],
+        ],
+      ],
+      YZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 0.01), matRedTransparent.clone()),
+          [0, 0.15, 0.15],
+          [0, Math.PI / 2, 0],
+        ],
+      ],
+      XZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 0.01), matGreenTransparent.clone()),
+          [0.15, 0, 0.15],
+          [-Math.PI / 2, 0, 0],
+        ],
+      ],
+    };
+
+    const pickerTranslate = {
+      X: [
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0.3, 0, 0],
+          [0, 0, -Math.PI / 2],
+        ],
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [-0.3, 0, 0],
+          [0, 0, Math.PI / 2],
+        ],
+      ],
+      Y: [
+        [new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible), [0, 0.3, 0]],
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0, -0.3, 0],
+          [0, 0, Math.PI],
+        ],
+      ],
+      Z: [
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0, 0, 0.3],
+          [Math.PI / 2, 0, 0],
+        ],
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0, 0, -0.3],
+          [-Math.PI / 2, 0, 0],
+        ],
+      ],
+      XYZ: [[new THREE.Mesh(new THREE.OctahedronGeometry(0.2, 0), matInvisible)]],
+      XY: [[new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.01), matInvisible), [0.15, 0.15, 0]]],
+      YZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.01), matInvisible),
+          [0, 0.15, 0.15],
+          [0, Math.PI / 2, 0],
+        ],
+      ],
+      XZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.01), matInvisible),
+          [0.15, 0, 0.15],
+          [-Math.PI / 2, 0, 0],
+        ],
+      ],
+    };
+
+    const helperTranslate = {
+      START: [
+        [
+          new THREE.Mesh(new THREE.OctahedronGeometry(0.01, 2), matHelper),
+          null,
+          null,
+          null,
+          "helper",
+        ],
+      ],
+      END: [
+        [
+          new THREE.Mesh(new THREE.OctahedronGeometry(0.01, 2), matHelper),
+          null,
+          null,
+          null,
+          "helper",
+        ],
+      ],
+      DELTA: [[new THREE.Line(TranslateHelperGeometry(), matHelper), null, null, null, "helper"]],
+      X: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [-1e3, 0, 0],
+          null,
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+      Y: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [0, -1e3, 0],
+          [0, 0, Math.PI / 2],
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+      Z: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [0, 0, -1e3],
+          [0, -Math.PI / 2, 0],
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+    };
+
+    const gizmoRotate = {
+      XYZE: [[new THREE.Mesh(CircleGeometry(0.5, 1), matGray), null, [0, Math.PI / 2, 0]]],
+      X: [[new THREE.Mesh(CircleGeometry(0.5, 0.5), matRed)]],
+      Y: [[new THREE.Mesh(CircleGeometry(0.5, 0.5), matGreen), null, [0, 0, -Math.PI / 2]]],
+      Z: [[new THREE.Mesh(CircleGeometry(0.5, 0.5), matBlue), null, [0, Math.PI / 2, 0]]],
+      E: [
+        [new THREE.Mesh(CircleGeometry(0.75, 1), matYellowTransparent), null, [0, Math.PI / 2, 0]],
+      ],
+    };
+
+    const helperRotate = {
+      AXIS: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [-1e3, 0, 0],
+          null,
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+    };
+
+    const pickerRotate = {
+      XYZE: [[new THREE.Mesh(new THREE.SphereGeometry(0.25, 10, 8), matInvisible)]],
+      X: [
+        [
+          new THREE.Mesh(new THREE.TorusGeometry(0.5, 0.1, 4, 24), matInvisible),
+          [0, 0, 0],
+          [0, -Math.PI / 2, -Math.PI / 2],
+        ],
+      ],
+      Y: [
+        [
+          new THREE.Mesh(new THREE.TorusGeometry(0.5, 0.1, 4, 24), matInvisible),
+          [0, 0, 0],
+          [Math.PI / 2, 0, 0],
+        ],
+      ],
+      Z: [
+        [
+          new THREE.Mesh(new THREE.TorusGeometry(0.5, 0.1, 4, 24), matInvisible),
+          [0, 0, 0],
+          [0, 0, -Math.PI / 2],
+        ],
+      ],
+      E: [[new THREE.Mesh(new THREE.TorusGeometry(0.75, 0.1, 2, 24), matInvisible)]],
+    };
+
+    const gizmoScale = {
+      X: [
+        [new THREE.Mesh(scaleHandleGeometry, matRed), [0.5, 0, 0], [0, 0, -Math.PI / 2]],
+        [new THREE.Mesh(lineGeometry2, matRed), [0, 0, 0], [0, 0, -Math.PI / 2]],
+        [new THREE.Mesh(scaleHandleGeometry, matRed), [-0.5, 0, 0], [0, 0, Math.PI / 2]],
+      ],
+      Y: [
+        [new THREE.Mesh(scaleHandleGeometry, matGreen), [0, 0.5, 0]],
+        [new THREE.Mesh(lineGeometry2, matGreen)],
+        [new THREE.Mesh(scaleHandleGeometry, matGreen), [0, -0.5, 0], [0, 0, Math.PI]],
+      ],
+      Z: [
+        [new THREE.Mesh(scaleHandleGeometry, matBlue), [0, 0, 0.5], [Math.PI / 2, 0, 0]],
+        [new THREE.Mesh(lineGeometry2, matBlue), [0, 0, 0], [Math.PI / 2, 0, 0]],
+        [new THREE.Mesh(scaleHandleGeometry, matBlue), [0, 0, -0.5], [-Math.PI / 2, 0, 0]],
+      ],
+      XY: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 0.01), matBlueTransparent),
+          [0.15, 0.15, 0],
+        ],
+      ],
+      YZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 0.01), matRedTransparent),
+          [0, 0.15, 0.15],
+          [0, Math.PI / 2, 0],
+        ],
+      ],
+      XZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 0.01), matGreenTransparent),
+          [0.15, 0, 0.15],
+          [-Math.PI / 2, 0, 0],
+        ],
+      ],
+      XYZ: [[new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.1, 0.1), matWhiteTransparent.clone())]],
+    };
+
+    const pickerScale = {
+      X: [
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0.3, 0, 0],
+          [0, 0, -Math.PI / 2],
+        ],
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [-0.3, 0, 0],
+          [0, 0, Math.PI / 2],
+        ],
+      ],
+      Y: [
+        [new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible), [0, 0.3, 0]],
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0, -0.3, 0],
+          [0, 0, Math.PI],
+        ],
+      ],
+      Z: [
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0, 0, 0.3],
+          [Math.PI / 2, 0, 0],
+        ],
+        [
+          new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0, 0.6, 4), matInvisible),
+          [0, 0, -0.3],
+          [-Math.PI / 2, 0, 0],
+        ],
+      ],
+      XY: [[new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.01), matInvisible), [0.15, 0.15, 0]]],
+      YZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.01), matInvisible),
+          [0, 0.15, 0.15],
+          [0, Math.PI / 2, 0],
+        ],
+      ],
+      XZ: [
+        [
+          new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.01), matInvisible),
+          [0.15, 0, 0.15],
+          [-Math.PI / 2, 0, 0],
+        ],
+      ],
+      XYZ: [[new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.2), matInvisible), [0, 0, 0]]],
+    };
+
+    const helperScale = {
+      X: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [-1e3, 0, 0],
+          null,
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+      Y: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [0, -1e3, 0],
+          [0, 0, Math.PI / 2],
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+      Z: [
+        [
+          new THREE.Line(lineGeometry, matHelper.clone()),
+          [0, 0, -1e3],
+          [0, -Math.PI / 2, 0],
+          [1e6, 1, 1],
+          "helper",
+        ],
+      ],
+    };
+
+    // Creates an THREE.Object3D with gizmos described in custom hierarchy definition.
+
+    function setupGizmo(gizmoMap) {
+      const gizmo = new THREE.Object3D();
+
+      for (const name in gizmoMap) {
+        for (let i = gizmoMap[name].length; i--; ) {
+          const object = gizmoMap[name][i][0].clone();
+          const position = gizmoMap[name][i][1];
+          const rotation = gizmoMap[name][i][2];
+          const scale = gizmoMap[name][i][3];
+          const tag = gizmoMap[name][i][4];
+
+          // name and tag properties are essential for picking and updating logic.
+          object.name = name;
+          object.tag = tag;
+
+          if (position) {
+            object.position.set(position[0], position[1], position[2]);
+          }
+
+          if (rotation) {
+            object.rotation.set(rotation[0], rotation[1], rotation[2]);
+          }
+
+          if (scale) {
+            object.scale.set(scale[0], scale[1], scale[2]);
+          }
+
+          object.updateMatrix();
+
+          const tempGeometry = object.geometry.clone();
+          tempGeometry.applyMatrix4(object.matrix);
+          object.geometry = tempGeometry;
+          object.renderOrder = Infinity;
+
+          object.position.set(0, 0, 0);
+          object.rotation.set(0, 0, 0);
+          object.scale.set(1, 1, 1);
+
+          gizmo.add(object);
+        }
+      }
+
+      return gizmo;
+    }
+
+    // Gizmo creation
+
+    this.gizmo = {};
+    this.picker = {};
+    this.helper = {};
+
+    this.add((this.gizmo["translate"] = setupGizmo(gizmoTranslate)));
+    this.add((this.gizmo["rotate"] = setupGizmo(gizmoRotate)));
+    this.add((this.gizmo["scale"] = setupGizmo(gizmoScale)));
+    this.add((this.picker["translate"] = setupGizmo(pickerTranslate)));
+    this.add((this.picker["rotate"] = setupGizmo(pickerRotate)));
+    this.add((this.picker["scale"] = setupGizmo(pickerScale)));
+    this.add((this.helper["translate"] = setupGizmo(helperTranslate)));
+    this.add((this.helper["rotate"] = setupGizmo(helperRotate)));
+    this.add((this.helper["scale"] = setupGizmo(helperScale)));
+
+    // Pickers should be hidden always
+
+    this.picker["translate"].visible = false;
+    this.picker["rotate"].visible = false;
+    this.picker["scale"].visible = false;
+  }
+
+  // updateMatrixWorld will update transformations and appearance of individual handles
+
+  updateMatrixWorld(force) {
+    const space = this.mode === "scale" ? "local" : this.space; // scale always oriented to local rotation
+
+    const quaternion = space === "local" ? this.worldQuaternion : _identityQuaternion;
+
+    // Show only gizmos for current transform mode
+
+    this.gizmo["translate"].visible = this.mode === "translate";
+    this.gizmo["rotate"].visible = this.mode === "rotate";
+    this.gizmo["scale"].visible = this.mode === "scale";
+
+    this.helper["translate"].visible = this.mode === "translate";
+    this.helper["rotate"].visible = this.mode === "rotate";
+    this.helper["scale"].visible = this.mode === "scale";
+
+    let handles = [];
+    handles = handles.concat(this.picker[this.mode].children);
+    handles = handles.concat(this.gizmo[this.mode].children);
+    handles = handles.concat(this.helper[this.mode].children);
+
+    for (let i = 0; i < handles.length; i++) {
+      const handle = handles[i];
+
+      // hide aligned to camera
+
+      handle.visible = true;
+      handle.rotation.set(0, 0, 0);
+      handle.position.copy(this.worldPosition);
+
+      let factor;
+
+      if (this.camera.isOrthographicCamera) {
+        factor = (this.camera.top - this.camera.bottom) / this.camera.zoom;
+      } else {
+        factor =
+          this.worldPosition.distanceTo(this.cameraPosition) *
+          Math.min((1.9 * Math.tan((Math.PI * this.camera.fov) / 360)) / this.camera.zoom, 7);
+      }
+
+      handle.scale.set(1, 1, 1).multiplyScalar((factor * this.size) / 4);
+
+      // TODO: simplify helpers and consider decoupling from gizmo
+
+      if (handle.tag === "helper") {
+        handle.visible = false;
+
+        if (handle.name === "AXIS") {
+          handle.visible = !!this.axis;
+
+          if (this.axis === "X") {
+            _tempQuaternion.setFromEuler(_tempEuler.set(0, 0, 0));
+            handle.quaternion.copy(quaternion).multiply(_tempQuaternion);
+
+            if (
+              Math.abs(_alignVector.copy(_unitX).applyQuaternion(quaternion).dot(this.eye)) > 0.9
+            ) {
+              handle.visible = false;
+            }
+          }
+
+          if (this.axis === "Y") {
+            _tempQuaternion.setFromEuler(_tempEuler.set(0, 0, Math.PI / 2));
+            handle.quaternion.copy(quaternion).multiply(_tempQuaternion);
+
+            if (
+              Math.abs(_alignVector.copy(_unitY).applyQuaternion(quaternion).dot(this.eye)) > 0.9
+            ) {
+              handle.visible = false;
+            }
+          }
+
+          if (this.axis === "Z") {
+            _tempQuaternion.setFromEuler(_tempEuler.set(0, Math.PI / 2, 0));
+            handle.quaternion.copy(quaternion).multiply(_tempQuaternion);
+
+            if (
+              Math.abs(_alignVector.copy(_unitZ).applyQuaternion(quaternion).dot(this.eye)) > 0.9
+            ) {
+              handle.visible = false;
+            }
+          }
+
+          if (this.axis === "XYZE") {
+            _tempQuaternion.setFromEuler(_tempEuler.set(0, Math.PI / 2, 0));
+            _alignVector.copy(this.rotationAxis);
+            handle.quaternion.setFromRotationMatrix(
+              _lookAtMatrix.lookAt(_zeroVector, _alignVector, _unitY),
+            );
+            handle.quaternion.multiply(_tempQuaternion);
+            handle.visible = this.dragging;
+          }
+
+          if (this.axis === "E") {
+            handle.visible = false;
+          }
+        } else if (handle.name === "START") {
+          handle.position.copy(this.worldPositionStart);
+          handle.visible = this.dragging;
+        } else if (handle.name === "END") {
+          handle.position.copy(this.worldPosition);
+          handle.visible = this.dragging;
+        } else if (handle.name === "DELTA") {
+          handle.position.copy(this.worldPositionStart);
+          handle.quaternion.copy(this.worldQuaternionStart);
+          _tempVector
+            .set(1e-10, 1e-10, 1e-10)
+            .add(this.worldPositionStart)
+            .sub(this.worldPosition)
+            .multiplyScalar(-1);
+          _tempVector.applyQuaternion(this.worldQuaternionStart.clone().invert());
+          handle.scale.copy(_tempVector);
+          handle.visible = this.dragging;
+        } else {
+          handle.quaternion.copy(quaternion);
+
+          if (this.dragging) {
+            handle.position.copy(this.worldPositionStart);
+          } else {
+            handle.position.copy(this.worldPosition);
+          }
+
+          if (this.axis) {
+            handle.visible = this.axis.search(handle.name) !== -1;
+          }
+        }
+
+        // If updating helper, skip rest of the loop
+        continue;
+      }
+
+      // Align handles to current local or world rotation
+
+      handle.quaternion.copy(quaternion);
+
+      if (this.mode === "translate" || this.mode === "scale") {
+        // Hide translate and scale axis facing the camera
+
+        const AXIS_HIDE_THRESHOLD = 0.99;
+        const PLANE_HIDE_THRESHOLD = 0.2;
+
+        if (handle.name === "X") {
+          if (
+            Math.abs(_alignVector.copy(_unitX).applyQuaternion(quaternion).dot(this.eye)) >
+            AXIS_HIDE_THRESHOLD
+          ) {
+            handle.scale.set(1e-10, 1e-10, 1e-10);
+            handle.visible = false;
+          }
+        }
+
+        if (handle.name === "Y") {
+          if (
+            Math.abs(_alignVector.copy(_unitY).applyQuaternion(quaternion).dot(this.eye)) >
+            AXIS_HIDE_THRESHOLD
+          ) {
+            handle.scale.set(1e-10, 1e-10, 1e-10);
+            handle.visible = false;
+          }
+        }
+
+        if (handle.name === "Z") {
+          if (
+            Math.abs(_alignVector.copy(_unitZ).applyQuaternion(quaternion).dot(this.eye)) >
+            AXIS_HIDE_THRESHOLD
+          ) {
+            handle.scale.set(1e-10, 1e-10, 1e-10);
+            handle.visible = false;
+          }
+        }
+
+        if (handle.name === "XY") {
+          if (
+            Math.abs(_alignVector.copy(_unitZ).applyQuaternion(quaternion).dot(this.eye)) <
+            PLANE_HIDE_THRESHOLD
+          ) {
+            handle.scale.set(1e-10, 1e-10, 1e-10);
+            handle.visible = false;
+          }
+        }
+
+        if (handle.name === "YZ") {
+          if (
+            Math.abs(_alignVector.copy(_unitX).applyQuaternion(quaternion).dot(this.eye)) <
+            PLANE_HIDE_THRESHOLD
+          ) {
+            handle.scale.set(1e-10, 1e-10, 1e-10);
+            handle.visible = false;
+          }
+        }
+
+        if (handle.name === "XZ") {
+          if (
+            Math.abs(_alignVector.copy(_unitY).applyQuaternion(quaternion).dot(this.eye)) <
+            PLANE_HIDE_THRESHOLD
+          ) {
+            handle.scale.set(1e-10, 1e-10, 1e-10);
+            handle.visible = false;
+          }
+        }
+      } else if (this.mode === "rotate") {
+        // Align handles to current local or world rotation
+
+        _tempQuaternion2.copy(quaternion);
+        _alignVector.copy(this.eye).applyQuaternion(_tempQuaternion.copy(quaternion).invert());
+
+        if (handle.name.search("E") !== -1) {
+          handle.quaternion.setFromRotationMatrix(
+            _lookAtMatrix.lookAt(this.eye, _zeroVector, _unitY),
+          );
+        }
+
+        if (handle.name === "X") {
+          _tempQuaternion.setFromAxisAngle(_unitX, Math.atan2(-_alignVector.y, _alignVector.z));
+          _tempQuaternion.multiplyQuaternions(_tempQuaternion2, _tempQuaternion);
+          handle.quaternion.copy(_tempQuaternion);
+        }
+
+        if (handle.name === "Y") {
+          _tempQuaternion.setFromAxisAngle(_unitY, Math.atan2(_alignVector.x, _alignVector.z));
+          _tempQuaternion.multiplyQuaternions(_tempQuaternion2, _tempQuaternion);
+          handle.quaternion.copy(_tempQuaternion);
+        }
+
+        if (handle.name === "Z") {
+          _tempQuaternion.setFromAxisAngle(_unitZ, Math.atan2(_alignVector.y, _alignVector.x));
+          _tempQuaternion.multiplyQuaternions(_tempQuaternion2, _tempQuaternion);
+          handle.quaternion.copy(_tempQuaternion);
+        }
+      }
+
+      // Hide disabled axes
+      handle.visible = handle.visible && (handle.name.indexOf("X") === -1 || this.showX);
+      handle.visible = handle.visible && (handle.name.indexOf("Y") === -1 || this.showY);
+      handle.visible = handle.visible && (handle.name.indexOf("Z") === -1 || this.showZ);
+      handle.visible =
+        handle.visible &&
+        (handle.name.indexOf("E") === -1 || (this.showX && this.showY && this.showZ));
+
+      // highlight selected axis
+
+      handle.material._color = handle.material._color || handle.material.color.clone();
+      handle.material._opacity = handle.material._opacity || handle.material.opacity;
+
+      handle.material.color.copy(handle.material._color);
+      handle.material.opacity = handle.material._opacity;
+
+      if (this.enabled && this.axis) {
+        if (handle.name === this.axis) {
+          handle.material.color.setHex(0xffff00);
+          handle.material.opacity = 1.0;
+        } else if (
+          this.axis.split("").some(function (a) {
+            return handle.name === a;
+          })
+        ) {
+          handle.material.color.setHex(0xffff00);
+          handle.material.opacity = 1.0;
+        }
+      }
+    }
+
+    super.updateMatrixWorld(force);
+  }
+}
+
+//
+
+class TransformControlsPlane extends THREE.Mesh {
+  constructor() {
+    super(
+      new THREE.PlaneGeometry(100000, 100000, 2, 2),
+      new THREE.MeshBasicMaterial({
+        visible: false,
+        wireframe: true,
+        side: THREE.DoubleSide,
+        transparent: true,
+        opacity: 0.1,
+        toneMapped: false,
+      }),
+    );
+
+    this.isTransformControlsPlane = true;
+
+    this.type = "TransformControlsPlane";
+  }
+
+  updateMatrixWorld(force) {
+    let space = this.space;
+
+    this.position.copy(this.worldPosition);
+
+    if (this.mode === "scale") space = "local"; // scale always oriented to local rotation
+
+    _v1
+      .copy(_unitX)
+      .applyQuaternion(space === "local" ? this.worldQuaternion : _identityQuaternion);
+    _v2
+      .copy(_unitY)
+      .applyQuaternion(space === "local" ? this.worldQuaternion : _identityQuaternion);
+    _v3
+      .copy(_unitZ)
+      .applyQuaternion(space === "local" ? this.worldQuaternion : _identityQuaternion);
+
+    // Align the plane for current transform mode, axis and space.
+
+    _alignVector.copy(_v2);
+
+    switch (this.mode) {
+      case "translate":
+      case "scale":
+        switch (this.axis) {
+          case "X":
+            _alignVector.copy(this.eye).cross(_v1);
+            _dirVector.copy(_v1).cross(_alignVector);
+            break;
+          case "Y":
+            _alignVector.copy(this.eye).cross(_v2);
+            _dirVector.copy(_v2).cross(_alignVector);
+            break;
+          case "Z":
+            _alignVector.copy(this.eye).cross(_v3);
+            _dirVector.copy(_v3).cross(_alignVector);
+            break;
+          case "XY":
+            _dirVector.copy(_v3);
+            break;
+          case "YZ":
+            _dirVector.copy(_v1);
+            break;
+          case "XZ":
+            _alignVector.copy(_v3);
+            _dirVector.copy(_v2);
+            break;
+          case "XYZ":
+          case "E":
+            _dirVector.set(0, 0, 0);
+            break;
+        }
+
+        break;
+      case "rotate":
+      default:
+        // special case for rotate
+        _dirVector.set(0, 0, 0);
+    }
+
+    if (_dirVector.length() === 0) {
+      // If in rotate mode, make the plane parallel to camera
+      this.quaternion.copy(this.cameraQuaternion);
+    } else {
+      _tempMatrix.lookAt(_tempVector.set(0, 0, 0), _dirVector, _alignVector);
+
+      this.quaternion.setFromRotationMatrix(_tempMatrix);
+    }
+
+    super.updateMatrixWorld(force);
+  }
+}
+
+export { TransformControls, TransformControlsGizmo, TransformControlsPlane };

--- a/src/core/view-helper.ts
+++ b/src/core/view-helper.ts
@@ -1,0 +1,375 @@
+import {
+  CylinderGeometry,
+  CanvasTexture,
+  Color,
+  Euler,
+  Mesh,
+  MeshBasicMaterial,
+  Object3D,
+  OrthographicCamera,
+  Quaternion,
+  Raycaster,
+  Sprite,
+  SpriteMaterial,
+  SRGBColorSpace,
+  Vector2,
+  Vector3,
+  Vector4,
+} from "three";
+
+import * as THREE from "three";
+
+class ViewHelper extends Object3D {
+  public isViewHelper = true;
+  public animating = false;
+  public center = new Vector3();
+
+  private readonly options: {
+    labelX?: string;
+    labelY?: string;
+    labelZ?: string;
+    font?: string;
+    color?: THREE.ColorRepresentation;
+    radius?: number;
+  } = {};
+
+  private readonly color1 = new Color("#ff4466");
+  private readonly color2 = new Color("#88ff44");
+  private readonly color3 = new Color("#4488ff");
+  private readonly color4 = new Color("#000000");
+
+  private readonly interactiveObjects: THREE.Sprite[] = [];
+  private readonly raycaster = new Raycaster();
+  private readonly mouse = new Vector2();
+  private readonly dummy = new Object3D();
+
+  private readonly orthoCamera = new OrthographicCamera(-2, 2, 2, -2, 0, 4);
+  private readonly geometry = new CylinderGeometry(0.04, 0.04, 0.8, 5)
+    .rotateZ(-Math.PI / 2)
+    .translate(0.4, 0, 0);
+  // private readonly geometry = new THREE.BoxGeometry(1, 1)
+  // .rotateZ(-Math.PI / 2)
+  // .translate(0.4, 0, 0);
+
+  private readonly xAxis = new Mesh(
+    this.geometry,
+    this.getAxisMaterial(this.color1)
+  );
+  private readonly yAxis = new Mesh(
+    this.geometry,
+    this.getAxisMaterial(this.color2)
+  );
+  private readonly zAxis = new Mesh(
+    this.geometry,
+    this.getAxisMaterial(this.color3)
+  );
+
+  private readonly posXAxisHelper: Sprite;
+  private readonly posYAxisHelper: Sprite;
+  private readonly posZAxisHelper: Sprite;
+  private readonly negXAxisHelper: Sprite;
+  private readonly negYAxisHelper: Sprite;
+  private readonly negZAxisHelper: Sprite;
+
+  private readonly point = new Vector3();
+  private readonly dim = 128;
+  private readonly turnRate = 2 * Math.PI; // turn rate in angles per second
+
+  private readonly targetPosition = new Vector3();
+  private readonly targetQuaternion = new Quaternion();
+
+  private readonly q1 = new Quaternion();
+  private readonly q2 = new Quaternion();
+  private readonly viewport = new Vector4();
+  private radius = 0;
+
+  public camera: THREE.PerspectiveCamera | THREE.OrthographicCamera;
+  private domElement: HTMLElement;
+
+  constructor(
+    camera: THREE.PerspectiveCamera | THREE.OrthographicCamera,
+    domElement: HTMLElement
+  ) {
+    super();
+    this.camera = camera;
+    this.domElement = domElement;
+
+    this.orthoCamera.position.set(0, 0, 2);
+
+    this.yAxis.rotation.z = Math.PI / 2;
+    this.zAxis.rotation.y = -Math.PI / 2;
+
+    this.add(this.xAxis);
+    this.add(this.zAxis);
+    this.add(this.yAxis);
+
+    const spriteMaterial1 = this.getSpriteMaterial(this.color1);
+    const spriteMaterial2 = this.getSpriteMaterial(this.color2);
+    const spriteMaterial3 = this.getSpriteMaterial(this.color3);
+    const spriteMaterial4 = this.getSpriteMaterial(this.color4);
+
+    this.posXAxisHelper = new Sprite(spriteMaterial1);
+    this.posYAxisHelper = new Sprite(spriteMaterial2);
+    this.posZAxisHelper = new Sprite(spriteMaterial3);
+    this.negXAxisHelper = new Sprite(spriteMaterial4);
+    this.negYAxisHelper = new Sprite(spriteMaterial4);
+    this.negZAxisHelper = new Sprite(spriteMaterial4);
+
+    this.posXAxisHelper.position.x = 1;
+    this.posYAxisHelper.position.y = 1;
+    this.posZAxisHelper.position.z = 1;
+    this.negXAxisHelper.position.x = -1;
+    this.negYAxisHelper.position.y = -1;
+    this.negZAxisHelper.position.z = -1;
+
+    this.negXAxisHelper.material.opacity = 0.2;
+    this.negYAxisHelper.material.opacity = 0.2;
+    this.negZAxisHelper.material.opacity = 0.2;
+
+    this.posXAxisHelper.userData.type = "posX";
+    this.posYAxisHelper.userData.type = "posY";
+    this.posZAxisHelper.userData.type = "posZ";
+    this.negXAxisHelper.userData.type = "negX";
+    this.negYAxisHelper.userData.type = "negY";
+    this.negZAxisHelper.userData.type = "negZ";
+
+    this.add(this.posXAxisHelper);
+    this.add(this.posYAxisHelper);
+    this.add(this.posZAxisHelper);
+    this.add(this.negXAxisHelper);
+    this.add(this.negYAxisHelper);
+    this.add(this.negZAxisHelper);
+
+    this.interactiveObjects.push(this.posXAxisHelper);
+    this.interactiveObjects.push(this.posYAxisHelper);
+    this.interactiveObjects.push(this.posZAxisHelper);
+    this.interactiveObjects.push(this.negXAxisHelper);
+    this.interactiveObjects.push(this.negYAxisHelper);
+    this.interactiveObjects.push(this.negZAxisHelper);
+  }
+
+  public render(renderer: THREE.WebGLRenderer) {
+    this.quaternion.copy(this.camera.quaternion).invert();
+    this.updateMatrixWorld();
+
+    this.point.set(0, 0, 1);
+    this.point.applyQuaternion(this.camera.quaternion);
+
+    const x = this.domElement.offsetWidth - this.dim;
+
+    renderer.getViewport(this.viewport);
+    renderer.setViewport(x, 0, this.dim, this.dim);
+
+    renderer.render(this, this.orthoCamera);
+
+    renderer.setViewport(
+      this.viewport.x,
+      this.viewport.y,
+      this.viewport.z,
+      this.viewport.w
+    );
+  }
+
+  protected handleClick(event: MouseEvent) {
+    event.stopPropagation();
+    if (this.animating === true) return false;
+
+    const rect = this.domElement.getBoundingClientRect();
+
+    const offsetX = rect.left + (this.domElement.offsetWidth - this.dim);
+    const offsetY = rect.top + (this.domElement.offsetHeight - this.dim);
+    this.mouse.x = ((event.clientX - offsetX) / (rect.right - offsetX)) * 2 - 1;
+    this.mouse.y =
+      -((event.clientY - offsetY) / (rect.bottom - offsetY)) * 2 + 1;
+
+    this.raycaster.setFromCamera(this.mouse, this.orthoCamera);
+
+    const intersects = this.raycaster.intersectObjects(this.interactiveObjects);
+
+    if (intersects.length > 0) {
+      const intersection = intersects[0];
+      const object = intersection.object;
+
+      this.prepareAnimationData(object, this.center);
+
+      this.animating = true;
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  protected setLabels(labelX: string, labelY: string, labelZ: string) {
+    this.options.labelX = labelX;
+    this.options.labelY = labelY;
+    this.options.labelZ = labelZ;
+    this.updateLabels();
+  }
+
+  protected setLabelStyle(
+    font: (typeof this.options)["font"],
+    color: (typeof this.options)["color"],
+    radius: (typeof this.options)["radius"]
+  ) {
+    this.options.font = font;
+    this.options.color = color;
+    this.options.radius = radius;
+    this.updateLabels();
+  }
+
+  public update(delta: number) {
+    const step = delta * this.turnRate;
+
+    // animate position by doing a slerp and then scaling the position on the unit sphere
+
+    this.q1.rotateTowards(this.q2, step);
+    this.camera.position
+      .set(0, 0, 1)
+      .applyQuaternion(this.q1)
+      .multiplyScalar(this.radius)
+      .add(this.center);
+
+    // animate orientation
+
+    this.camera.quaternion.rotateTowards(this.targetQuaternion, step);
+
+    if (this.q1.angleTo(this.q2) === 0) {
+      this.animating = false;
+    }
+  }
+
+  public dispose() {
+    this.geometry.dispose();
+
+    this.xAxis.material.dispose();
+    this.yAxis.material.dispose();
+    this.zAxis.material.dispose();
+
+    this.posXAxisHelper.material.map?.dispose();
+    this.posYAxisHelper.material.map?.dispose();
+    this.posZAxisHelper.material.map?.dispose();
+    this.negXAxisHelper.material.map?.dispose();
+    this.negYAxisHelper.material.map?.dispose();
+    this.negZAxisHelper.material.map?.dispose();
+
+    this.posXAxisHelper.material.dispose();
+    this.posYAxisHelper.material.dispose();
+    this.posZAxisHelper.material.dispose();
+    this.negXAxisHelper.material.dispose();
+    this.negYAxisHelper.material.dispose();
+    this.negZAxisHelper.material.dispose();
+  }
+
+  private prepareAnimationData(
+    object: THREE.Object3D,
+    focusPoint: THREE.Vector3
+  ) {
+    switch (object.userData.type) {
+      case "posX":
+        this.targetPosition.set(1, 0, 0);
+        this.targetQuaternion.setFromEuler(new Euler(0, Math.PI * 0.5, 0));
+        break;
+
+      case "posY":
+        this.targetPosition.set(0, 1, 0);
+        this.targetQuaternion.setFromEuler(new Euler(-Math.PI * 0.5, 0, 0));
+        break;
+
+      case "posZ":
+        this.targetPosition.set(0, 0, 1);
+        this.targetQuaternion.setFromEuler(new Euler());
+        break;
+
+      case "negX":
+        this.targetPosition.set(-1, 0, 0);
+        this.targetQuaternion.setFromEuler(new Euler(0, -Math.PI * 0.5, 0));
+        break;
+
+      case "negY":
+        this.targetPosition.set(0, -1, 0);
+        this.targetQuaternion.setFromEuler(new Euler(Math.PI * 0.5, 0, 0));
+        break;
+
+      case "negZ":
+        this.targetPosition.set(0, 0, -1);
+        this.targetQuaternion.setFromEuler(new Euler(0, Math.PI, 0));
+        break;
+
+      default:
+        console.error("ViewHelper: Invalid axis.");
+    }
+
+    //
+
+    this.radius = this.camera.position.distanceTo(focusPoint);
+    this.targetPosition.multiplyScalar(this.radius).add(focusPoint);
+
+    this.dummy.position.copy(focusPoint);
+
+    this.dummy.lookAt(this.camera.position);
+    this.q1.copy(this.dummy.quaternion);
+
+    this.dummy.lookAt(this.targetPosition);
+    this.q2.copy(this.dummy.quaternion);
+  }
+
+  private getAxisMaterial(color: THREE.ColorRepresentation) {
+    return new MeshBasicMaterial({ color: color, toneMapped: false });
+  }
+
+  private getSpriteMaterial(color: THREE.Color, text?: string) {
+    const {
+      font = "24px Arial",
+      color: labelColor = "#000000",
+      radius = 14,
+    } = this.options;
+    const canvas = document.createElement("canvas");
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const context = canvas.getContext("2d");
+    context!.beginPath();
+    context!.arc(32, 32, radius, 0, 2 * Math.PI);
+    context!.closePath();
+    context!.fillStyle = color.getStyle();
+    context!.fill();
+
+    if (text) {
+      context!.font = font;
+      context!.textAlign = "center";
+      context!.fillStyle = labelColor as string;
+      context!.fillText(text, 32, 41);
+    }
+
+    const texture = new CanvasTexture(canvas);
+    texture.colorSpace = SRGBColorSpace;
+
+    return new SpriteMaterial({ map: texture, toneMapped: false });
+  }
+
+  protected updateLabels() {
+    this.posXAxisHelper.material.map?.dispose();
+    this.posYAxisHelper.material.map?.dispose();
+    this.posZAxisHelper.material.map?.dispose();
+
+    this.posXAxisHelper.material.dispose();
+    this.posYAxisHelper.material.dispose();
+    this.posZAxisHelper.material.dispose();
+
+    this.posXAxisHelper.material = this.getSpriteMaterial(
+      this.color1,
+      this.options.labelX
+    );
+    this.posYAxisHelper.material = this.getSpriteMaterial(
+      this.color2,
+      this.options.labelY
+    );
+    this.posZAxisHelper.material = this.getSpriteMaterial(
+      this.color3,
+      this.options.labelZ
+    );
+  }
+}
+
+export { ViewHelper };

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,26 @@
+import { useEffect, RefObject } from "react";
+
+interface useOutsideClickProps {
+  ref: RefObject<HTMLElement>;
+  callback: () => void;
+}
+
+export const useOutsideClick = ({
+  ref,
+  callback,
+}: useOutsideClickProps) => {
+    
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+
+  }, [ref, close]);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,28 @@ body {
 }
 
 
+.split {
+  display: flex;
+}
+
+.gutter {
+  /* background-color: #111114; */
+  background-color: 000;
+  background-repeat: no-repeat;
+  background-position: 50%;
+}
+
+
+.gutter.gutter-horizontal {
+  /* background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg=="); */
+  cursor: col-resize;
+}
+
+.gutter.gutter-verical:hover {
+  /* background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg=="); */
+  cursor: row-resize;
+}
+
 .scroll-bar::-webkit-scrollbar {
   width: 10px;
   height: 8px;

--- a/src/pages/asset/index.tsx
+++ b/src/pages/asset/index.tsx
@@ -1,0 +1,15 @@
+import Toolbar from "@/components/Toolbar";
+import Icon from "@/components/Icon";
+
+export default function Asset() {
+  return (
+    <main className="bg-black-300 flex h-full max-h-full w-full min-w-full flex-col rounded-t-lg">
+      <Toolbar.Container className="justify-between px-[0.5rem]">
+        <div className="flex items-center gap-1">
+          <Icon icon="Folder" size={14} />
+          <p>Asset</p>
+        </div>
+      </Toolbar.Container>
+    </main>
+  );
+}

--- a/src/pages/hierarchy/index.tsx
+++ b/src/pages/hierarchy/index.tsx
@@ -1,0 +1,15 @@
+import Toolbar from "@/components/Toolbar";
+import Icon from "@/components/Icon";
+
+export default function Hierarchy() {
+  return (
+    <main className="bg-black-300 flex h-full max-h-full w-full min-w-full flex-col rounded-t-lg">
+      <Toolbar.Container className="h-[1.8rem] justify-between px-[0.5rem]">
+        <div className="flex items-center gap-1">
+          <Icon icon="Network" size={14} className="mt-[0.05rem]" />
+          <p className="relative mt-0.5">Hierarchy</p>
+        </div>
+      </Toolbar.Container>
+    </main>
+  );
+}

--- a/src/pages/inspector/index.tsx
+++ b/src/pages/inspector/index.tsx
@@ -1,0 +1,15 @@
+import Toolbar from "@/components/Toolbar";
+import Icon from "@/components/Icon";
+
+export default function Inspector() {
+  return (
+    <main className="bg-black-300 flex h-full max-h-full w-full min-w-full flex-col rounded-t-lg">
+      <Toolbar.Container className="h-[1.8rem] justify-between px-[0.5rem]">
+        <div className="flex items-center gap-1">
+          <Icon icon="Hammer" size={14} />
+          <p>Inspector</p>
+        </div>
+      </Toolbar.Container>
+    </main>
+  );
+}

--- a/src/pages/scene-editor/index.tsx
+++ b/src/pages/scene-editor/index.tsx
@@ -1,0 +1,31 @@
+import Split from "@/components/Split";
+import Panel from "@/components/Panel";
+import SceneView from "./scene-view";
+import Asset from "../asset";
+import Hierarchy from "../hierarchy";
+import Inspector from "../inspector";
+
+export default function SceneEditor() {
+  return (
+    <div className="flex h-full max-h-screen w-full max-w-full flex-col bg-black">
+      <Split size={[80, 20]} direction="horizontal">
+        <Split size={[100, 0]} direction="vertical">
+          <Panel>
+            <SceneView />
+          </Panel>
+          <Panel>
+            <Asset />
+          </Panel>
+        </Split>
+        <Split size={[35, 65]} direction="vertical">
+          <Panel>
+            <Hierarchy />
+          </Panel>
+          <Panel className="pt-0">
+            <Inspector />
+          </Panel>
+        </Split>
+      </Split>
+    </div>
+  );
+}

--- a/src/pages/scene-editor/scene-view/_components/Menubar.tsx
+++ b/src/pages/scene-editor/scene-view/_components/Menubar.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/utils/style";
+import { MenuItem } from "@/constants/menu";
+
+interface MenubarProps {
+  className?: string;
+  menu: MenuItem[];
+}
+export function Menubar({ className, menu }: MenubarProps) {
+  return (
+    <div
+      className={cn(
+        `bg-black-300 flex min-h-[1.8rem] w-full overflow-hidden rounded-t-lg py-[0.02rem]`,
+        className,
+      )}
+    >
+      {menu.map((item) => (
+        <MenubarItem key={item.label} item={item} />
+      ))}
+    </div>
+  );
+}
+
+interface MenubarItemProps {
+  item: MenuItem;
+}
+
+function MenubarItem({ item }: MenubarItemProps) {
+  return (
+    <div className="hover:bg-black-100 flex h-full w-fit items-center rounded-md px-2">
+      {item.label}
+    </div>
+  );
+}

--- a/src/pages/scene-editor/scene-view/_components/SceneViewToolbar.tsx
+++ b/src/pages/scene-editor/scene-view/_components/SceneViewToolbar.tsx
@@ -1,0 +1,61 @@
+import Toolbar from "@/components/Toolbar";
+
+import { Context } from "@/core/context";
+import Icon from "@/components/Icon";
+
+function SceneViewToolbar() {
+  const handleClickChange2DView = () => {
+    const context = Context.getInstance();
+    context.scene!.change2DView();
+  };
+
+  return (
+    <Toolbar.Container className="bg-black-700 h-auto pt-[0.1rem]">
+      <div className="flex items-center gap-2">
+        <Toolbar.Item shape="rect" size="md">
+          <Icon icon="Plus" />
+        </Toolbar.Item>
+        <Toolbar.Group>
+          <Toolbar.Item shape="rect" size="md">
+            <Icon icon="Dot" />
+          </Toolbar.Item>
+          <Toolbar.Item shape="rect" size="md" selected={true}>
+            <Icon icon="SquareDashed" />
+          </Toolbar.Item>
+          <Toolbar.Item shape="rect" size="md">
+            <Icon icon="Square" />
+          </Toolbar.Item>
+          <Toolbar.Item shape="rect" size="md">
+            <Icon icon="Square" className="fill-[#D1D1D377]" />
+          </Toolbar.Item>
+        </Toolbar.Group>
+        <Toolbar.Group>
+          <Toolbar.Item shape="rect" size="md">
+            <Icon icon="Slash" />
+          </Toolbar.Item>
+          <Toolbar.Item shape="rect" size="md">
+            <Icon icon="Spline" />
+          </Toolbar.Item>
+        </Toolbar.Group>
+      </div>
+      <Toolbar.Group className="absolute right-0 gap-0.5">
+        <Toolbar.Item
+          shape="rect"
+          size="md"
+          className="w-8 text-[0.75rem]"
+          onClick={handleClickChange2DView}
+        >
+          2D
+        </Toolbar.Item>
+        <Toolbar.Item shape="rect" size="md" className="w-8">
+          <Icon icon="Video" className="h-4 w-4" />
+        </Toolbar.Item>
+        <Toolbar.Item shape="rect" size="md" className="w-8">
+          <Icon icon="Grid" className="h-4 w-4" />
+        </Toolbar.Item>
+      </Toolbar.Group>
+    </Toolbar.Container>
+  );
+}
+
+export default SceneViewToolbar;

--- a/src/pages/scene-editor/scene-view/index.tsx
+++ b/src/pages/scene-editor/scene-view/index.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { Context } from "@/core/context";
+import { cn } from "@/utils/style";
+import SceneViewToolbar from "./_components/SceneViewToolbar";
+import { Menubar } from "./_components/Menubar";
+import { SCENE_VIEW_HEADER_MENU_ITEMS } from "@/constants/menu";
+
+export default function SceneView({ className }: { className?: string }) {
+  const sceneViewRef = useRef<HTMLDivElement>(null);
+
+  const context = Context.getInstance();
+
+  useEffect(() => {
+    if (sceneViewRef.current) {
+      console.time("SceneView Render");
+      context.didMount(sceneViewRef.current);
+      console.timeEnd("SceneView Render");
+    }
+
+    return () => {
+      console.log("%cUnMount", "color: red");
+      context.dispose();
+    };
+  }, []);
+
+  return (
+    <div className="flex h-full flex-1 flex-col">
+      <Menubar menu={SCENE_VIEW_HEADER_MENU_ITEMS} className="bg-black-500" />
+      <SceneViewToolbar />
+      <section className="relative h-full">
+        <div
+          ref={sceneViewRef}
+          className={cn(
+            "from-black-500 to-black-100 relative h-full w-full overflow-hidden rounded-b-lg bg-gradient-to-b",
+            "bg-[#404040]",
+            // "bg-radial-[at_50%_75%] from-black-200  to-black-500 to-90%",
+            className,
+          )}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/types/mesh.ts
+++ b/src/types/mesh.ts
@@ -1,0 +1,8 @@
+export type MeshType =
+  | "Group"
+  | "Box"
+  | "Plane"
+  | "Sphere"
+  | "Cylinder"
+  | "Cone"
+  | "Torus";

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -1,0 +1,88 @@
+import * as THREE from "three";
+import JEASINGS from "jeasings";
+import { Context } from "../core/context";
+
+const duration = 250;
+
+let position: JEASINGS.JEasing | null = null;
+let quaternion: JEASINGS.JEasing | null = null;
+export type CameraTypes =
+  | THREE.Camera
+  | THREE.PerspectiveCamera
+  | THREE.OrthographicCamera;
+export const moveCamera = (target: CameraTypes, callback?: () => void) => {
+  const context = Context.getInstance();
+  const currentCamera = context.camera as CameraTypes;
+
+  context.scene!.selectedCamera = target;
+
+  const isSamePosition = currentCamera.position.equals(
+    target.getWorldPosition(new THREE.Vector3())
+  );
+  const isSameQuaternion = currentCamera.quaternion.equals(
+    target.getWorldQuaternion(new THREE.Quaternion())
+  );
+
+  if (isSamePosition && isSameQuaternion) {
+    const originalCamera = context.scene?.originalCamera?.clone();
+    if (originalCamera) {
+      position = movePosition(originalCamera, currentCamera, callback);
+      quaternion = moveRotation(originalCamera, currentCamera, callback);
+    }
+  } else {
+    context.scene!.originalCamera = currentCamera.clone() as THREE.Camera;
+    position = movePosition(target, currentCamera, callback);
+    quaternion = moveRotation(target, currentCamera, callback);
+  }
+
+  position!.start();
+  quaternion!.start();
+};
+
+const movePosition = (
+  target: CameraTypes,
+  camera: CameraTypes,
+  callback?: () => void
+) => {
+  const worldPos = target.getWorldPosition(new THREE.Vector3());
+  const position = new JEASINGS.JEasing(camera.position)
+    .to({ x: worldPos.x, y: worldPos.y, z: worldPos.z }, duration)
+    .easing(JEASINGS.Quadratic.Out)
+    .onComplete(() => {
+      const context = Context.getInstance();
+      context.scene!.selectedCamera = null;
+      console.log("완료");
+
+      if (callback) {
+        callback();
+      }
+    });
+
+  return position;
+};
+
+const moveRotation = (
+  target: CameraTypes,
+  camera: CameraTypes,
+  callback?: () => void
+) => {
+  const worldQuarternion = target.getWorldQuaternion(new THREE.Quaternion());
+  const quaternion = new JEASINGS.JEasing(camera.quaternion)
+    .to(
+      {
+        x: worldQuarternion.x,
+        y: worldQuarternion.y,
+        z: worldQuarternion.z,
+        w: worldQuarternion.w,
+      },
+      duration
+    )
+    .easing(JEASINGS.Quadratic.Out)
+    .onComplete(() => {
+      if (callback) {
+        callback();
+      }
+    });
+
+  return quaternion;
+};

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,7 @@
+const random = () => {
+  return Math.random() * 0xffffff;
+};
+
+export const Color = {
+  random: random,
+};

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,0 +1,16 @@
+import * as THREE from "three";
+
+export const getVector3FromEvent = (
+  event: MouseEvent
+): THREE.Vector3 | undefined => {
+  if (event.currentTarget) {
+    const target = event.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+
+    return new THREE.Vector3(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1,
+      0
+    );
+  }
+};

--- a/src/utils/mesh.ts
+++ b/src/utils/mesh.ts
@@ -1,0 +1,57 @@
+import * as THREE from "three";
+import { MeshType } from "../types/mesh";
+
+declare module "three" {
+  interface Object3D {
+    graph: THREE.Object3D[];
+  }
+  interface Mesh {
+    graph: THREE.Object3D[];
+  }
+}
+
+export const createMesh = (type: MeshType): THREE.Mesh | THREE.Group => {
+  let mesh: THREE.Mesh | THREE.Group;
+  if (type === "Group") {
+    mesh = new THREE.Group();
+    mesh.name = `New Group`;
+    mesh["graph"] = [];
+
+    return mesh;
+  } else {
+    mesh = new THREE.Mesh();
+    mesh["graph"] = [];
+
+    const geometry = createGeometry(type);
+    const material = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(0xffffff),
+      side: THREE.DoubleSide,
+    });
+    mesh.geometry = geometry;
+    mesh.material = material;
+    mesh.position.set(0, 0, 0);
+
+    mesh.name = `New ${type}`;
+
+    return mesh;
+  }
+};
+
+const createGeometry = (type: MeshType): THREE.BufferGeometry => {
+  switch (type) {
+    case "Box":
+      return new THREE.BoxGeometry(1, 1, 1);
+    case "Plane":
+      return new THREE.PlaneGeometry(1, 1);
+    case "Sphere":
+      return new THREE.SphereGeometry(1, 32, 16);
+    case "Cylinder":
+      return new THREE.CylinderGeometry(0.5, 0.5, 1, 32);
+    case "Cone":
+      return new THREE.ConeGeometry(0.5, 1, 32);
+    case "Torus":
+      return new THREE.TorusGeometry(0.5, 0.2, 16, 64);
+    default:
+      return new THREE.BoxGeometry(1, 1, 1);
+  }
+};

--- a/src/utils/vector.ts
+++ b/src/utils/vector.ts
@@ -1,0 +1,9 @@
+import * as THREE from "three";
+
+export const random = (range: number) => {
+  return new THREE.Vector3(Math.random() * range, Math.random() * range, Math.random() * range);
+};
+
+export const Vector = {
+  random: random,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,13 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Path mapping */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src", "electron"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,11 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## 📝작업 내용
Editor의 기본 화면 구성을 구현하였습니다.
* 화면 분할
  * `SceneView` 편집할 Scene을 보여줍니다
  * `Hierarchy` Scene에 올라가 있는 오브젝트를 표시하는 패널입니다. (레이아웃만 구현)
  * `Inspector` 선택한 오브젝트에 대한 정보를 표시하는 패널입니다. (레이아웃만 구현)
  *  `Asset` 로컬 파일을 표시하여 편집중인 Scene의 Project 경로의 파일들을 표시합니다. (레이아웃만 구현)

### 스크린샷 (선택)

<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/9382d01a-0c05-4194-8412-666d6affb2fb" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
